### PR TITLE
Split tiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,15 @@ geojson/us-lowzoom-factory:
 	make geojson/us-lowzoom/states.geojson
 	make geojson/us-lowzoom/counties.geojson
 	make geojson/us-lowzoom/districts.geojson
+	make geojson/us-lowzoom/districts_115.geojson
+	for f in $$(ls geojson/us-lowzoom) ; do mv geojson/us-lowzoom/$$f geojson/us-lowzoom/$$(basename $$f .json).geojson; done
 
 geojson/us-smallest-factory:
 	make geojson/us-smallest/states.geojson
 	make geojson/us-smallest/counties.geojson
 	make geojson/us-smallest/districts.geojson
+	make geojson/us-smallest/districts_115.geojson
+	for f in $$(ls geojson/us-smallest) ; do mv geojson/us-smallest/$$f geojson/us-smallest/$$(basename $$f .json).geojson; done
 
 #
 # Albers
@@ -369,11 +373,11 @@ tiles/counties:
 	make tiles/counties-z4-6.mbtiles
 	make tiles/counties-z7-12.mbtiles
 
-tiles/districts_114: 
-	make tiles/districts_114-z0-1.mbtiles
-	make tiles/districts_114-z2-3.mbtiles
-	make tiles/districts_114-z4-6.mbtiles
-	make tiles/districts_114-z7-12.mbtiles
+tiles/districts: 
+	make tiles/districts-z0-1.mbtiles
+	make tiles/districts-z2-3.mbtiles
+	make tiles/districts-z4-6.mbtiles
+	make tiles/districts-z7-12.mbtiles
 
 tiles/districts_115: 
 	make tiles/districts_115-z0-1.mbtiles

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ geojson/us-10m-factory:
 	make geojson/us-10m/districts_115.geojson
 	for f in $$(ls geojson/us-10m) ; do mv geojson/us-10m/$$f geojson/us-10m/$$(basename $$f .json).geojson; done
 
-geojson/us-lowzoom-factory: 
+geojson/us-lowzoom-factory:
 	make geojson/us-lowzoom/states.geojson
 	make geojson/us-lowzoom/counties.geojson
 	make geojson/us-lowzoom/districts.geojson
@@ -179,7 +179,7 @@ geojson/albers/state-bounds.json: geojson/albers/states.geojson
 
 # Separate asset needed by wapo-components
 geojson/albers/tile-index.json: geojson/albers/us-10m
-	cat $^/states.geojson geojson/cartogram/boundaries.geojson \
+	cat $^/states.geojson geojson/cartogram/boundaries.geojson geojson/albers/state-label-callouts.geojson \
 		| ./reproject-geojson --projection mercator --reverse \
 		| node_modules/.bin/tile-index -z 5 -f indexed > $@
 
@@ -391,7 +391,7 @@ tiles/%-z7-12.mbtiles: geojson/albers/us-10m/%.geojson
 		--name=2016-us-election-$* \
 		--output $@
 
-tiles/states: 
+tiles/states:
 	make tiles/states-z0-1.mbtiles
 	make tiles/states-z2-3.mbtiles
 	make tiles/states-z4-6.mbtiles
@@ -403,20 +403,20 @@ tiles/counties:
 	make tiles/counties-z4-6.mbtiles
 	make tiles/counties-z7-12.mbtiles
 
-tiles/districts: 
+tiles/districts:
 	make tiles/districts-z0-1.mbtiles
 	make tiles/districts-z2-3.mbtiles
 	make tiles/districts-z4-6.mbtiles
 	make tiles/districts-z7-12.mbtiles
 
-tiles/districts_115: 
+tiles/districts_115:
 	make tiles/districts_115-z0-1.mbtiles
 	make tiles/districts_115-z2-3.mbtiles
 	make tiles/districts_115-z4-6.mbtiles
 	make tiles/districts_115-z7-12.mbtiles
 
 tiles/precincts:
-	make tiles/precincts-z7-12.mbtiles	
+	make tiles/precincts-z7-12.mbtiles
 
 tiles/election-%.mbtiles: tiles/%-z0-1.mbtiles tiles/%-z2-3.mbtiles tiles/%-z4-6.mbtiles tiles/%-z7-12.mbtiles
 	tile-join -f -o $@ tiles/$*-z0-1.mbtiles tiles/$*-z2-3.mbtiles tiles/$*-z4-6.mbtiles tiles/$*-z7-12.mbtiles

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ tiles/election-state-labels.mbtiles: geojson/albers/state-labels.geojson \
 		--no-polygon-splitting \
 		--drop-rate=0 \
 		--name=2016-us-election-labels \
-		--buffer 20 \
+		--buffer 128 \
 		--output $@
 
 tiles/%-z0-1.mbtiles: geojson/albers/us-smallest/%.geojson
@@ -443,7 +443,7 @@ upload-all:
 	./upload washingtonpost.ds-2016-election-districts16-v1 tiles/election-districts_115.mbtiles
 	./upload washingtonpost.ds-2016-election-counties-v1 tiles/election-counties.mbtiles
 	./upload washingtonpost.ds-2016-election-states-v1 tiles/election-states.mbtiles
-	./upload washingtonpost.ds-2016-election-state-labels-v3 tiles/election-state-labels.mbtiles
+	./upload washingtonpost.ds-2016-election-state-labels-v4 tiles/election-state-labels.mbtiles
 	./upload washingtonpost.ds-2016-election-cartogram-v3 tiles/election-cartogram.mbtiles
 	./upload washingtonpost.ds-2016-election-centroids-v4 tiles/election-centroids.mbtiles
 	./upload washingtonpost.ds-2016-election-city-labels-v8 tiles/election-city-labels.mbtiles

--- a/Makefile
+++ b/Makefile
@@ -268,11 +268,17 @@ geojson/albers/city-labels.geojson:
 				name:name \
 		> $@
 
-tiles/merged.mbtiles: tiles/election.mbtiles \
+tiles/merged.mbtiles: tiles/election-districts.mbtiles \
+	tiles/election-districts_115.mbtiles \
+	tiles/election-counties.mbtiles \
+	tiles/election-states.mbtiles \
+	tiles/election-state-labels.mbtiles \
+	tiles/election-cartogram.mbtiles \
 	tiles/election-centroids.mbtiles \
 	tiles/election-city-labels.mbtiles
 	tile-join -fo $@ $^
-	echo "Merged tiles built as $@.  Upload this file to s3://wapo-election-tiles/merged-vX.mbtiles, and then update wapo-components/build_scripts/build-screenshotter.sh to point to the new version."
+	echo "Merged tiles built. Please upload with the following command and then update the version number in wapo-components/build_scripts/build-screenshotter.sh."
+	echo SKIP_MAPBOX=1 ./upload merged-v7 tiles/merged.mbtiles
 
 tiles/election-centroids.mbtiles: geojson/albers/centroid-states.geojson \
 	geojson/albers/centroid-counties.geojson \
@@ -328,9 +334,9 @@ tiles/election-state-labels.mbtiles: geojson/albers/state-labels.geojson \
 		--named-layer=state-label-callouts:geojson/albers/state-label-callouts.geojson \
 		--read-parallel \
 		--no-polygon-splitting \
-		--maximum-zoom=1 \
 		--drop-rate=0 \
 		--name=2016-us-election-labels \
+		--buffer 20 \
 		--output $@
 
 tiles/%-z0-1.mbtiles: geojson/albers/us-smallest/%.geojson
@@ -431,6 +437,16 @@ ifndef TILESET
 endif
 	./upload $(TILESET) $^
 
+
+upload-all:
+	./upload washingtonpost.ds-2016-election-districts-v1 tiles/election-districts.mbtiles
+	./upload washingtonpost.ds-2016-election-districts16-v1 tiles/election-districts_115.mbtiles
+	./upload washingtonpost.ds-2016-election-counties-v1 tiles/election-counties.mbtiles
+	./upload washingtonpost.ds-2016-election-states-v1 tiles/election-states.mbtiles
+	./upload washingtonpost.ds-2016-election-state-labels-v3 tiles/election-state-labels.mbtiles
+	./upload washingtonpost.ds-2016-election-cartogram-v3 tiles/election-cartogram.mbtiles
+	./upload washingtonpost.ds-2016-election-centroids-v4 tiles/election-centroids.mbtiles
+	./upload washingtonpost.ds-2016-election-city-labels-v8 tiles/election-city-labels.mbtiles
 
 #
 # State legislative districts

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ geojson/cartogram:
 geojson/cartogram/cartogram-bounds.json: geojson/cartogram/boundaries.geojson
 	cat $^ | ./extract-projected-bounds > $@
 
+
 geojson/albers/state-labels-dataset.geojson:
 	# Note: Need to preclude this with Mapbox Token
 	curl "https://api.mapbox.com/datasets/v1/devseed/cis7wq7mj04l92zpk9tbk9wgo/features?access_token=$(MapboxAccessToken)" > $@
@@ -290,93 +291,105 @@ tiles/election-city-labels.mbtiles: geojson/albers/city-labels.geojson
 		--buffer=20 \
 		--output $@
 
-tiles/z0-1.mbtiles: geojson/albers/us-smallest/states.geojson \
-	geojson/albers/us-smallest/counties.geojson \
-	geojson/albers/us-smallest/districts.geojson \
-	geojson/albers/state-labels.geojson \
+tiles/election-state-labels.mbtiles: geojson/albers/state-labels.geojson \
 	geojson/albers/state-label-callouts.geojson
 	mkdir -p $(dir $@)
 	tippecanoe --projection EPSG:3857 \
 		-f \
-		--named-layer=states:geojson/albers/us-smallest/states.geojson \
-		--named-layer=counties:geojson/albers/us-smallest/counties.geojson \
-		--named-layer=districts:geojson/albers/us-smallest/districts.geojson \
-		--named-layer=precincts:geojson/albers/us-smallest/precincts.geojson \
 		--named-layer=state-labels:geojson/albers/state-labels.geojson \
 		--named-layer=state-label-callouts:geojson/albers/state-label-callouts.geojson \
 		--read-parallel \
 		--no-polygon-splitting \
 		--maximum-zoom=1 \
 		--drop-rate=0 \
-		--name=2016-us-election \
+		--name=2016-us-election-labels \
 		--output $@
 
-tiles/z2-3.mbtiles: geojson/albers/us-lowzoom/states.geojson \
-	geojson/albers/us-lowzoom/counties.geojson \
-	geojson/albers/us-lowzoom/districts.geojson \
-	geojson/albers/state-labels.geojson \
-	geojson/albers/state-label-callouts.geojson
+tiles/%-z0-1.mbtiles: geojson/albers/us-smallest/%.geojson
 	mkdir -p $(dir $@)
 	tippecanoe --projection EPSG:3857 \
 		-f \
-		--named-layer=states:geojson/albers/us-lowzoom/states.geojson \
-		--named-layer=counties:geojson/albers/us-lowzoom/counties.geojson \
-		--named-layer=districts:geojson/albers/us-lowzoom/districts.geojson \
-		--named-layer=state-labels:geojson/albers/state-labels.geojson \
-		--named-layer=state-label-callouts:geojson/albers/state-label-callouts.geojson \
+		--named-layer=$*:geojson/albers/us-smallest/$*.geojson \
+		--read-parallel \
+		--no-polygon-splitting \
+		--maximum-zoom=1 \
+		--drop-rate=0 \
+		--name=2016-us-election-$* \
+		--output $@
+
+tiles/%-z2-3.mbtiles: geojson/albers/us-lowzoom/%.geojson
+	mkdir -p $(dir $@)
+	tippecanoe --projection EPSG:3857 \
+		-f \
+		--named-layer=$*:geojson/albers/us-lowzoom/$*.geojson \
 		--read-parallel \
 		--no-polygon-splitting \
 		--minimum-zoom=2 \
 		--maximum-zoom=3 \
 		--drop-rate=0 \
-		--name=2016-us-election \
+		--name=2016-us-election-$* \
 		--output $@
 
-tiles/z4-6.mbtiles: geojson/albers/us-10m \
-	geojson/albers/state-labels.geojson \
-	geojson/albers/state-label-callouts.geojson
+tiles/%-z4-6.mbtiles: geojson/albers/us-10m/%.geojson
 	mkdir -p $(dir $@)
 	tippecanoe --projection EPSG:3857 \
 		-f \
-		--named-layer=states:geojson/albers/us-10m/states.geojson \
-		--named-layer=counties:geojson/albers/us-10m/counties.geojson \
-		--named-layer=districts:geojson/albers/us-10m/districts.geojson \
-		--named-layer=precincts:geojson/albers/us-10m/precincts.geojson \
-		--named-layer=state-labels:geojson/albers/state-labels.geojson \
-		--named-layer=state-label-callouts:geojson/albers/state-label-callouts.geojson \
+		--named-layer=$*:geojson/albers/$*.geojson \
 		--read-parallel \
 		--no-polygon-splitting \
 		--minimum-zoom=4 \
 		--maximum-zoom=6 \
 		--drop-rate=0 \
-		--name=2016-us-election \
+		--name=2016-us-election-$* \
 		--output $@
 
-tiles/z7-12.mbtiles: geojson/albers/states.geojson \
-	geojson/albers/counties.geojson \
-	geojson/albers/districts.geojson \
-	geojson/albers/precincts.geojson \
-	geojson/albers/state-labels.geojson \
-	geojson/albers/state-label-callouts.geojson
+
+tiles/%-z7-12.mbtiles: geojson/albers/us-10m/%.geojson
 	mkdir -p $(dir $@)
 	tippecanoe --projection EPSG:3857 \
 		-f \
-		--named-layer=states:geojson/albers/states.geojson \
-		--named-layer=counties:geojson/albers/counties.geojson \
-		--named-layer=districts:geojson/albers/districts.geojson \
-		--named-layer=precincts:geojson/albers/precincts.geojson \
-		--named-layer=state-labels:geojson/albers/state-labels.geojson \
-		--named-layer=state-label-callouts:geojson/albers/state-label-callouts.geojson \
+		--named-layer=$*:geojson/albers/$*.geojson \
 		--read-parallel \
 		--no-polygon-splitting \
 		--minimum-zoom=7 \
 		--maximum-zoom=12 \
 		--drop-rate=0 \
-		--name=2016-us-election \
+		--name=2016-us-election-$* \
 		--output $@
 
-tiles/election.mbtiles: geojson/albers/relative-area.csv tiles/z0-1.mbtiles tiles/z2-3.mbtiles tiles/z4-6.mbtiles tiles/z7-12.mbtiles
-	tile-join -f -o $@ -c geojson/albers/relative-area.csv tiles/z0-1.mbtiles tiles/z2-3.mbtiles tiles/z4-6.mbtiles tiles/z7-12.mbtiles
+tiles/states: 
+	make tiles/states-z0-1.mbtiles
+	make tiles/states-z2-3.mbtiles
+	make tiles/states-z4-6.mbtiles
+	make tiles/states-z7-12.mbtiles
+
+tiles/counties:
+	make tiles/counties-z0-1.mbtiles
+	make tiles/counties-z2-3.mbtiles
+	make tiles/counties-z4-6.mbtiles
+	make tiles/counties-z7-12.mbtiles
+
+tiles/districts_114: 
+	make tiles/districts_114-z0-1.mbtiles
+	make tiles/districts_114-z2-3.mbtiles
+	make tiles/districts_114-z4-6.mbtiles
+	make tiles/districts_114-z7-12.mbtiles
+
+tiles/districts_115: 
+	make tiles/districts_115-z0-1.mbtiles
+	make tiles/districts_115-z2-3.mbtiles
+	make tiles/districts_115-z4-6.mbtiles
+	make tiles/districts_115-z7-12.mbtiles
+
+tiles/precincts:
+	make tiles/precincts-z7-12.mbtiles	
+
+tiles/election-%.mbtiles: tiles/%-z0-1.mbtiles tiles/%-z2-3.mbtiles tiles/%-z4-6.mbtiles tiles/%-z7-12.mbtiles
+	tile-join -f -o $@ -c tiles/$*-z0-1.mbtiles tiles/$*-z2-3.mbtiles tiles/$*-z4-6.mbtiles tiles/$*-z7-12.mbtiles
+
+tile-factory-%:
+	make tiles/$*
+	make tiles/election-$*.mbtiles
 
 # Usage:
 # TILESET=accountname.tilesetname make upload/tiles-filename

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,22 @@ geojson/precincts.geojson: geojson/precincts.ndjson
 	cat $^ | jq -s '{type: "FeatureCollection", features: .}' > $@
 
 # Simplified copies certain geojson targets
-geojson/us-10m: geojson/counties.geojson geojson/districts.geojson geojson/states.geojson geojson/precincts.geojson
-	mkdir -p $@
+# geojson/us-10m: geojson/counties.geojson geojson/districts.geojson geojson/states.geojson geojson/precincts.geojson
+# 	mkdir -p $@
+# 	node_modules/.bin/topojson \
+# 		-o $(dir $@)temp.json \
+# 		--no-pre-quantization \
+# 		--post-quantization=1e6 \
+# 		--simplify=7e-7 \
+# 		--properties id,GEOID,STATE_FIPS,FIPS\
+# 		--external-properties data/fips.csv \
+# 		-- $^
+# 	node_modules/.bin/topojson-geojson -o $@ $(dir $@)temp.json
+# 	for f in $$(ls $@) ; do mv $@/$$f $@/$$(basename $$f .json).geojson; done
+# 	rm $(dir $@)temp.json
+
+geojson/us-10m/%: geojson/%
+	mkdir -p geojson/us-10m
 	node_modules/.bin/topojson \
 		-o $(dir $@)temp.json \
 		--no-pre-quantization \
@@ -59,9 +73,8 @@ geojson/us-10m: geojson/counties.geojson geojson/districts.geojson geojson/state
 		--properties id,GEOID,STATE_FIPS,FIPS\
 		--external-properties data/fips.csv \
 		-- $^
-	node_modules/.bin/topojson-geojson -o $@ $(dir $@)temp.json
-	for f in $$(ls $@) ; do mv $@/$$f $@/$$(basename $$f .json).geojson; done
-	rm $(dir $@)temp.json
+	node_modules/.bin/topojson-geojson -o geojson/us-10m geojson/us-10m/temp.json
+	rm geojson/us-10m/temp.json
 
 geojson/us-lowzoom/%: geojson/%
 	mkdir -p geojson/us-lowzoom
@@ -88,6 +101,14 @@ geojson/us-smallest/%: geojson/%
 		-- $^
 	node_modules/.bin/topojson-geojson -o geojson/us-smallest geojson/us-smallest/temp.json
 	rm geojson/us-smallest/temp.json
+
+geojson/us-10m-factory:
+	make geojson/us-10m/counties.geojson
+	make geojson/us-10m/states.geojson
+	make geojson/us-10m/precincts.geojson
+	make geojson/us-10m/districts.geojson
+	make geojson/us-10m/districts_115.geojson
+	for f in $$(ls geojson/us-10m) ; do mv geojson/us-10m/$$f geojson/us-10m/$$(basename $$f .json).geojson; done
 
 geojson/us-lowzoom-factory: 
 	make geojson/us-lowzoom/states.geojson
@@ -118,17 +139,20 @@ geojson/albers/us-10m: geojson/us-10m
 	make geojson/albers/us-10m/states.geojson
 	make geojson/albers/us-10m/counties.geojson
 	make geojson/albers/us-10m/districts.geojson
+	make geojson/albers/us-10m/districts_115.geojson
 	make geojson/albers/us-10m/precincts.geojson
 
 geojson/albers/us-lowzoom: geojson/us-lowzoom
 	make geojson/albers/us-lowzoom/states.geojson
 	make geojson/albers/us-lowzoom/counties.geojson
 	make geojson/albers/us-lowzoom/districts.geojson
+	make geojson/albers/us-lowzoom/districts_115.geojson
 
 geojson/albers/us-smallest: geojson/us-smallest
 	make geojson/albers/us-smallest/states.geojson
 	make geojson/albers/us-smallest/counties.geojson
 	make geojson/albers/us-smallest/districts.geojson
+	make geojson/albers/us-smallest/districts_115.geojson
 
 geojson/albers/relative-area.csv: geojson/albers/us-10m
 	$(eval TOTAL_AREA = \

--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ tiles/precincts:
 	make tiles/precincts-z7-12.mbtiles	
 
 tiles/election-%.mbtiles: tiles/%-z0-1.mbtiles tiles/%-z2-3.mbtiles tiles/%-z4-6.mbtiles tiles/%-z7-12.mbtiles
-	tile-join -f -o $@ -c tiles/$*-z0-1.mbtiles tiles/$*-z2-3.mbtiles tiles/$*-z4-6.mbtiles tiles/$*-z7-12.mbtiles
+	tile-join -f -o $@ tiles/$*-z0-1.mbtiles tiles/$*-z2-3.mbtiles tiles/$*-z4-6.mbtiles tiles/$*-z7-12.mbtiles
 
 tile-factory-%:
 	make tiles/$*

--- a/data/us-cities.geojson
+++ b/data/us-cities.geojson
@@ -9,50 +9,6 @@
     {
       "geometry": {
         "coordinates": [
-          -72.575813234126827,
-          44.259971536326248
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "adm1name": "Vermont",
-        "align": null,
-        "latitude": 44.259972,
-        "longitude": -72.575813,
-        "name": "Montpelier",
-        "namealt": null,
-        "national": null,
-        "pop_max": 20000,
-        "scalerank": 8,
-        "visible": 1
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          -73.212466879962676,
-          44.47579815579337
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "adm1name": "Vermont",
-        "align": "right",
-        "latitude": 44.475798,
-        "longitude": -73.212467,
-        "name": "Burlington",
-        "namealt": null,
-        "national": null,
-        "pop_max": 20000,
-        "scalerank": 8,
-        "visible": 1
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
           -107.612486004449238,
           45.73176800443116
         ],
@@ -61,13 +17,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 45.731768,
-        "longitude": -107.612486,
         "name": "Hardin",
-        "namealt": null,
         "national": null,
         "pop_max": 4448,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -83,13 +35,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 47.108583,
-        "longitude": -104.710493,
         "name": "Glendive",
-        "namealt": null,
         "national": null,
         "pop_max": 5856,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -105,13 +53,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 45.215675,
-        "longitude": -112.683985,
         "name": "Dillon",
-        "namealt": null,
         "national": null,
         "pop_max": 4463,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -127,13 +71,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 47.688005,
-        "longitude": -114.156686,
         "name": "Polson",
-        "namealt": null,
         "national": null,
         "pop_max": 5326,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -149,13 +89,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 46.408884,
-        "longitude": -105.839984,
         "name": "Miles City",
-        "namealt": null,
         "national": null,
         "pop_max": 8615,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -171,13 +107,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 45.680092,
-        "longitude": -111.037832,
         "name": "Bozeman",
-        "namealt": null,
         "national": null,
         "pop_max": 44921,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -193,13 +125,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 48.183970,
-        "longitude": -106.635259,
         "name": "Glasgow",
-        "namealt": null,
         "national": null,
         "pop_max": 3240,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -215,13 +143,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 46.003896,
-        "longitude": -112.533839,
         "name": "Butte",
-        "namealt": null,
         "national": null,
         "pop_max": 34190,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -237,13 +161,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 48.545240,
-        "longitude": -109.677683,
         "name": "Havre",
-        "namealt": null,
         "national": null,
         "pop_max": 11154,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -259,13 +179,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 48.197767,
-        "longitude": -114.315979,
         "name": "Kalispell",
-        "namealt": null,
         "national": null,
         "pop_max": 32062,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -281,13 +197,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 45.788302,
-        "longitude": -108.540000,
         "name": "Billings",
-        "namealt": null,
         "national": null,
         "pop_max": 104552,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -303,13 +215,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 47.500291,
-        "longitude": -111.299987,
         "name": "Great Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 66558,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -325,13 +233,9 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 46.872241,
-        "longitude": -113.993053,
         "name": "Missoula",
-        "namealt": null,
         "national": null,
         "pop_max": 72856,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -347,14 +251,10 @@
       "properties": {
         "adm1name": "Montana",
         "align": null,
-        "latitude": 46.592749,
-        "longitude": -112.035291,
         "name": "Helena",
-        "namealt": null,
         "national": null,
         "pop_max": 38725,
-        "scalerank": 3,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -369,13 +269,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.051948,
-        "longitude": -122.978034,
         "name": "Springfield",
-        "namealt": null,
         "national": null,
         "pop_max": 56032,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -391,13 +287,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 45.455247,
-        "longitude": -123.842503,
         "name": "Tillamook",
-        "namealt": null,
         "national": null,
         "pop_max": 8145,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -413,13 +305,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.026627,
-        "longitude": -116.961889,
         "name": "Ontario",
-        "namealt": null,
         "national": null,
         "pop_max": 12187,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -435,13 +323,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 45.324687,
-        "longitude": -118.086601,
         "name": "La Grande",
-        "namealt": null,
         "national": null,
         "pop_max": 15004,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -457,13 +341,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 43.218433,
-        "longitude": -123.356099,
         "name": "Roseburg",
-        "namealt": null,
         "national": null,
         "pop_max": 30479,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -479,13 +359,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 45.672598,
-        "longitude": -118.787489,
         "name": "Pendleton",
-        "namealt": null,
         "national": null,
         "pop_max": 16799,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -501,13 +377,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.416525,
-        "longitude": -118.952026,
         "name": "John Day",
-        "namealt": null,
         "national": null,
         "pop_max": 1573,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -523,13 +395,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 42.439540,
-        "longitude": -123.327186,
         "name": "Grants Pass",
-        "namealt": null,
         "national": null,
         "pop_max": 46189,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -545,13 +413,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.572356,
-        "longitude": -123.279979,
         "name": "Corvallis",
-        "namealt": null,
         "national": null,
         "pop_max": 59030,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -567,13 +431,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.620492,
-        "longitude": -123.086942,
         "name": "Albany",
-        "namealt": null,
         "national": null,
         "pop_max": 51376,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -589,13 +449,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 46.188381,
-        "longitude": -123.829997,
         "name": "Astoria",
-        "namealt": null,
         "national": null,
         "pop_max": 10011,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -611,13 +467,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 42.326627,
-        "longitude": -122.874423,
         "name": "Medford",
-        "namealt": null,
         "national": null,
         "pop_max": 108525,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -633,13 +485,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 42.225005,
-        "longitude": -121.780536,
         "name": "Klamath Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 42978,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -655,13 +503,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.050010,
-        "longitude": -123.100016,
         "name": "Eugene",
-        "namealt": null,
         "national": null,
         "pop_max": 245158,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -677,13 +521,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 43.366615,
-        "longitude": -124.216589,
         "name": "Coos Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 31976,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -699,13 +539,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": null,
-        "latitude": 44.071921,
-        "longitude": -121.309996,
         "name": "Bend",
-        "namealt": null,
         "national": null,
         "pop_max": 75441,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -720,14 +556,10 @@
       },
       "properties": {
         "adm1name": "Oregon",
-        "align": "bottom",
-        "latitude": 44.928070,
-        "longitude": -123.023897,
+        "align": null,
         "name": "Salem",
-        "namealt": null,
         "national": null,
         "pop_max": 229010,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -743,13 +575,9 @@
       "properties": {
         "adm1name": "Oregon",
         "align": "bottom",
-        "latitude": 45.520024,
-        "longitude": -122.679990,
         "name": "Portland",
-        "namealt": null,
         "national": null,
         "pop_max": 1875000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -765,13 +593,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.751943,
-        "longitude": -80.319423,
         "name": "Beaver Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 120125,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -787,13 +611,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.518598,
-        "longitude": -78.394967,
         "name": "Altoona",
-        "namealt": null,
         "national": null,
         "pop_max": 78607,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -809,13 +629,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 41.241086,
-        "longitude": -77.001383,
         "name": "Williamsport",
-        "namealt": null,
         "national": null,
         "pop_max": 56877,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -831,13 +647,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.037774,
-        "longitude": -76.305766,
         "name": "Lancaster",
-        "namealt": null,
         "national": null,
         "pop_max": 209489,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -853,13 +665,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.599988,
-        "longitude": -75.500028,
         "name": "Allentown",
-        "namealt": null,
         "national": null,
         "pop_max": 496442,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -875,13 +683,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 39.962921,
-        "longitude": -76.728040,
         "name": "York",
-        "namealt": null,
         "national": null,
         "pop_max": 218010,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -897,13 +701,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.327085,
-        "longitude": -78.922222,
         "name": "Johnstown",
-        "namealt": null,
         "national": null,
         "pop_max": 69286,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -919,13 +719,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 41.409293,
-        "longitude": -75.662679,
         "name": "Scranton",
-        "namealt": null,
         "national": null,
         "pop_max": 156196,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -941,13 +737,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.793723,
-        "longitude": -77.860245,
         "name": "State College",
-        "namealt": null,
         "national": null,
         "pop_max": 87926,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -963,13 +755,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 42.129921,
-        "longitude": -80.084993,
         "name": "Erie",
-        "namealt": null,
         "national": null,
         "pop_max": 178182,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -985,13 +773,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 41.249044,
-        "longitude": -75.877937,
         "name": "Wilkes Barre",
-        "namealt": null,
         "national": null,
         "pop_max": 158913,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1007,14 +791,10 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.273600,
-        "longitude": -76.884749,
         "name": "Harrisburg",
-        "namealt": null,
         "national": null,
         "pop_max": 528892,
-        "scalerank": 6,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -1029,13 +809,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": null,
-        "latitude": 40.429999,
-        "longitude": -79.999985,
         "name": "Pittsburgh",
-        "namealt": null,
         "national": null,
         "pop_max": 1838000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -1051,13 +827,9 @@
       "properties": {
         "adm1name": "Pennsylvania",
         "align": "right",
-        "latitude": 39.999973,
-        "longitude": -75.169996,
         "name": "Philadelphia",
-        "namealt": null,
         "national": null,
         "pop_max": 5492000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -1073,13 +845,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 34.769724,
-        "longitude": -84.970302,
         "name": "Dalton",
-        "namealt": null,
         "national": null,
         "pop_max": 58557,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1095,13 +863,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 33.955613,
-        "longitude": -84.543248,
         "name": "Marietta",
-        "namealt": null,
         "national": null,
         "pop_max": 61360,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1117,13 +881,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 31.213817,
-        "longitude": -82.354906,
         "name": "Waycross",
-        "namealt": null,
         "national": null,
         "pop_max": 19824,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1139,13 +899,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 33.036471,
-        "longitude": -85.031875,
         "name": "La Grange",
-        "namealt": null,
         "national": null,
         "pop_max": 31776,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1161,13 +917,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 30.832858,
-        "longitude": -83.278597,
         "name": "Valdosta",
-        "namealt": null,
         "national": null,
         "pop_max": 61179,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1183,13 +935,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 31.578730,
-        "longitude": -84.155830,
         "name": "Albany",
-        "namealt": null,
         "national": null,
         "pop_max": 88766,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1205,13 +953,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 33.961298,
-        "longitude": -83.378022,
         "name": "Athens",
-        "namealt": null,
         "national": null,
         "pop_max": 110301,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1227,13 +971,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 32.850384,
-        "longitude": -83.630048,
         "name": "Macon",
-        "namealt": null,
         "national": null,
         "pop_max": 115592,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1249,13 +989,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 32.470433,
-        "longitude": -84.980017,
         "name": "Columbus",
-        "namealt": null,
         "national": null,
         "pop_max": 217980,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -1271,13 +1007,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 31.507778,
-        "longitude": -82.850690,
         "name": "Douglas",
-        "namealt": null,
         "national": null,
         "pop_max": 13441,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1293,13 +1025,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 32.537457,
-        "longitude": -82.918283,
         "name": "Dublin",
-        "namealt": null,
         "national": null,
         "pop_max": 22623,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1315,13 +1043,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 31.149687,
-        "longitude": -81.491651,
         "name": "Brunswick",
-        "namealt": null,
         "national": null,
         "pop_max": 47085,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -1337,13 +1061,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 33.460812,
-        "longitude": -81.984981,
         "name": "Augusta",
-        "namealt": null,
         "national": null,
         "pop_max": 262332,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -1359,13 +1079,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": "right",
-        "latitude": 32.021106,
-        "longitude": -81.109995,
         "name": "Savannah",
-        "namealt": null,
         "national": null,
         "pop_max": 180187,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -1381,13 +1097,9 @@
       "properties": {
         "adm1name": "Georgia",
         "align": null,
-        "latitude": 33.830014,
-        "longitude": -84.399949,
         "name": "Atlanta",
-        "namealt": null,
         "national": 1,
         "pop_max": 4506000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -1403,13 +1115,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 33.581941,
-        "longitude": -112.195824,
         "name": "Glendale",
-        "namealt": null,
         "national": null,
         "pop_max": 500000,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1425,13 +1133,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.833821,
-        "longitude": -109.706880,
         "name": "Safford",
-        "namealt": null,
         "national": null,
         "pop_max": 10668,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1447,13 +1151,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.879374,
-        "longitude": -111.756626,
         "name": "Casa Grande",
-        "namealt": null,
         "national": null,
         "pop_max": 44655,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1469,13 +1169,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 33.423915,
-        "longitude": -111.736084,
         "name": "Mesa",
-        "namealt": null,
         "national": null,
         "pop_max": 1085394,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1491,13 +1187,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 34.498293,
-        "longitude": -114.308279,
         "name": "Lake Havasu City",
-        "namealt": null,
         "national": null,
         "pop_max": 56133,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1513,13 +1205,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 35.148176,
-        "longitude": -114.567488,
         "name": "Bullhead City",
-        "namealt": null,
         "national": null,
         "pop_max": 37989,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1535,13 +1223,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 35.284705,
-        "longitude": -110.700695,
         "name": "Winslow",
-        "namealt": null,
         "national": null,
         "pop_max": 9931,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1557,13 +1241,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.950378,
-        "longitude": -112.724655,
         "name": "Gila Bend",
-        "namealt": null,
         "national": null,
         "pop_max": 2088,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1579,13 +1259,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 31.713140,
-        "longitude": -110.066884,
         "name": "Tombstone",
-        "namealt": null,
         "national": null,
         "pop_max": 1570,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1601,13 +1277,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.253211,
-        "longitude": -109.831394,
         "name": "Willcox",
-        "namealt": null,
         "national": null,
         "pop_max": 5146,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1623,13 +1295,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 33.692348,
-        "longitude": -111.868040,
         "name": "Scottsdale",
-        "namealt": null,
         "national": null,
         "pop_max": 15401,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1645,13 +1313,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 35.189879,
-        "longitude": -114.052222,
         "name": "Kingman",
-        "namealt": null,
         "national": null,
         "pop_max": 42182,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1667,13 +1331,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 36.054788,
-        "longitude": -112.138592,
         "name": "Grand Canyon",
-        "namealt": null,
         "national": null,
         "pop_max": 1550,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -1689,13 +1349,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.685278,
-        "longitude": -114.623608,
         "name": "Yuma",
-        "namealt": null,
         "national": null,
         "pop_max": 92489,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -1711,13 +1367,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 34.590019,
-        "longitude": -112.447772,
         "name": "Prescott",
-        "namealt": null,
         "national": null,
         "pop_max": 55038,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -1733,13 +1385,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 31.358640,
-        "longitude": -109.548363,
         "name": "Douglas",
-        "namealt": null,
         "national": null,
         "pop_max": 30185,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -1755,13 +1403,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 35.198096,
-        "longitude": -111.650508,
         "name": "Flagstaff",
-        "namealt": null,
         "national": null,
         "pop_max": 63993,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -1777,13 +1421,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": null,
-        "latitude": 32.204997,
-        "longitude": -110.889986,
         "name": "Tucson",
-        "namealt": null,
         "national": null,
         "pop_max": 823000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -1799,13 +1439,9 @@
       "properties": {
         "adm1name": "Arizona",
         "align": "bottom",
-        "latitude": 33.539980,
-        "longitude": -112.069992,
         "name": "Phoenix",
-        "namealt": "Phoenix-Mesa",
         "national": 1,
         "pop_max": 3551000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -1821,13 +1457,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.674186,
-        "longitude": -96.369684,
         "name": "Bryan",
-        "namealt": null,
         "national": null,
         "pop_max": 146692,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1843,13 +1475,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.883071,
-        "longitude": -97.941113,
         "name": "San Marcos",
-        "namealt": null,
         "national": null,
         "pop_max": 70371,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1865,13 +1493,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.500534,
-        "longitude": -94.740274,
         "name": "Longview",
-        "namealt": null,
         "national": null,
         "pop_max": 75920,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1887,13 +1511,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 26.203038,
-        "longitude": -98.229725,
         "name": "McAllen",
-        "namealt": null,
         "national": null,
         "pop_max": 364004,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1909,13 +1529,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 26.197560,
-        "longitude": -97.690198,
         "name": "Harlingen",
-        "namealt": null,
         "national": null,
         "pop_max": 110339,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1931,13 +1547,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 27.750462,
-        "longitude": -98.070484,
         "name": "Alice",
-        "namealt": null,
         "national": null,
         "pop_max": 22655,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1953,13 +1565,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.697811,
-        "longitude": -98.126321,
         "name": "New Braunfels",
-        "namealt": null,
         "national": null,
         "pop_max": 45840,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1975,13 +1583,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.351525,
-        "longitude": -97.392490,
         "name": "Cleburne",
-        "namealt": null,
         "national": null,
         "pop_max": 35545,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -1997,13 +1601,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.707895,
-        "longitude": -98.982315,
         "name": "Brownwood",
-        "namealt": null,
         "national": null,
         "pop_max": 20988,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2019,13 +1619,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.360717,
-        "longitude": -103.665001,
         "name": "Alpine",
-        "namealt": null,
         "national": null,
         "pop_max": 6587,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2041,13 +1637,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.042484,
-        "longitude": -104.832242,
         "name": "Van Horn",
-        "namealt": null,
         "national": null,
         "pop_max": 2175,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2063,13 +1655,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.243186,
-        "longitude": -101.475186,
         "name": "Big Spring",
-        "namealt": null,
         "national": null,
         "pop_max": 24122,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2085,13 +1673,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 34.151054,
-        "longitude": -99.290384,
         "name": "Vernon",
-        "namealt": null,
         "national": null,
         "pop_max": 11660,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2107,13 +1691,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 34.424887,
-        "longitude": -100.213920,
         "name": "Childress",
-        "namealt": null,
         "national": null,
         "pop_max": 6557,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2129,13 +1709,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 34.821917,
-        "longitude": -102.398592,
         "name": "Hereford",
-        "namealt": null,
         "national": null,
         "pop_max": 15675,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2151,13 +1727,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 36.060808,
-        "longitude": -102.518611,
         "name": "Dalhart",
-        "namealt": null,
         "national": null,
         "pop_max": 7088,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2173,13 +1745,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.410878,
-        "longitude": -94.962767,
         "name": "Texas City",
-        "namealt": null,
         "national": null,
         "pop_max": 69914,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2195,13 +1763,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.660863,
-        "longitude": -95.147743,
         "name": "Pasadena",
-        "namealt": null,
         "national": null,
         "pop_max": 628492,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2217,13 +1781,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.755844,
-        "longitude": -94.967728,
         "name": "Baytown",
-        "namealt": null,
         "national": null,
         "pop_max": 86034,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2239,13 +1799,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.684761,
-        "longitude": -97.020238,
         "name": "Arlington",
-        "namealt": null,
         "national": null,
         "pop_max": 724777,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -2261,13 +1817,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.312063,
-        "longitude": -95.455864,
         "name": "Conroe",
-        "namealt": null,
         "national": null,
         "pop_max": 41643,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2283,13 +1835,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.603741,
-        "longitude": -94.655267,
         "name": "Nacogdoches",
-        "namealt": null,
         "national": null,
         "pop_max": 30691,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2305,13 +1853,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.711024,
-        "longitude": -100.489277,
         "name": "Eagle Pass",
-        "namealt": null,
         "national": null,
         "pop_max": 53276,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2327,13 +1871,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 26.303186,
-        "longitude": -98.159962,
         "name": "Edinburg",
-        "namealt": null,
         "national": null,
         "pop_max": 150000,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2349,13 +1889,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 27.515955,
-        "longitude": -97.855846,
         "name": "Kingsville",
-        "namealt": null,
         "national": null,
         "pop_max": 25264,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2371,13 +1907,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.898988,
-        "longitude": -93.928593,
         "name": "Port Arthur",
-        "namealt": null,
         "national": null,
         "pop_max": 56945,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2393,13 +1925,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.723769,
-        "longitude": -95.550587,
         "name": "Huntsville",
-        "namealt": null,
         "national": null,
         "pop_max": 35590,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2415,13 +1943,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.117285,
-        "longitude": -97.727482,
         "name": "Killeen",
-        "namealt": null,
         "national": null,
         "pop_max": 137919,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2437,13 +1961,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.338435,
-        "longitude": -94.728880,
         "name": "Lufkin",
-        "namealt": null,
         "national": null,
         "pop_max": 43264,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2459,13 +1979,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.362948,
-        "longitude": -100.896384,
         "name": "Del Rio",
-        "namealt": null,
         "national": null,
         "pop_max": 36068,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2481,13 +1997,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.464008,
-        "longitude": -100.436697,
         "name": "San Angelo",
-        "namealt": null,
         "national": null,
         "pop_max": 88256,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2503,13 +2015,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 33.635995,
-        "longitude": -96.608584,
         "name": "Sherman",
-        "namealt": null,
         "national": null,
         "pop_max": 40284,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2525,13 +2033,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.086263,
-        "longitude": -94.101683,
         "name": "Beaumont",
-        "namealt": null,
         "national": null,
         "pop_max": 111485,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2547,13 +2051,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.981111,
-        "longitude": -95.964360,
         "name": "Bay City",
-        "namealt": null,
         "national": null,
         "pop_max": 18663,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2569,13 +2069,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.616017,
-        "longitude": -96.629694,
         "name": "Port Lavaca",
-        "namealt": null,
         "national": null,
         "pop_max": 11743,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2591,13 +2087,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 27.226903,
-        "longitude": -98.144899,
         "name": "Falfurrias",
-        "namealt": null,
         "national": null,
         "pop_max": 5349,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2613,13 +2105,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.405978,
-        "longitude": -97.750840,
         "name": "Beeville",
-        "namealt": null,
         "national": null,
         "pop_max": 13004,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2635,13 +2123,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.891692,
-        "longitude": -102.884997,
         "name": "Fort Stockton",
-        "namealt": null,
         "national": null,
         "pop_max": 7721,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2657,13 +2141,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.415794,
-        "longitude": -103.499895,
         "name": "Pecos",
-        "namealt": null,
         "national": null,
         "pop_max": 8372,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2679,13 +2159,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 35.862396,
-        "longitude": -101.966887,
         "name": "Dumas",
-        "namealt": null,
         "national": null,
         "pop_max": 13629,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2701,13 +2177,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 33.215762,
-        "longitude": -97.128837,
         "name": "Denton",
-        "namealt": null,
         "national": null,
         "pop_max": 176930,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2723,13 +2195,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.030718,
-        "longitude": -102.097500,
         "name": "Midland",
-        "namealt": null,
         "national": null,
         "pop_max": 98501,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2745,13 +2213,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.102093,
-        "longitude": -97.363008,
         "name": "Temple",
-        "namealt": null,
         "national": null,
         "pop_max": 61161,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -2767,13 +2231,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.301143,
-        "longitude": -94.797480,
         "name": "Galveston",
-        "namealt": null,
         "national": null,
         "pop_max": 68612,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2789,13 +2249,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.959484,
-        "longitude": -95.356877,
         "name": "Freeport",
-        "namealt": null,
         "national": null,
         "pop_max": 74892,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2811,13 +2267,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 28.804998,
-        "longitude": -97.003340,
         "name": "Victoria",
-        "namealt": null,
         "national": null,
         "pop_max": 64209,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2833,13 +2285,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.845561,
-        "longitude": -102.367225,
         "name": "Odessa",
-        "namealt": null,
         "national": null,
         "pop_max": 106054,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2855,13 +2303,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 33.913626,
-        "longitude": -98.493068,
         "name": "Wichita Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 101212,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2877,13 +2321,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 31.549171,
-        "longitude": -97.146381,
         "name": "Waco",
-        "namealt": null,
         "national": null,
         "pop_max": 167347,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2899,13 +2339,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 33.580003,
-        "longitude": -101.879968,
         "name": "Lubbock",
-        "namealt": null,
         "national": null,
         "pop_max": 213300,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2921,13 +2357,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.448625,
-        "longitude": -99.732786,
         "name": "Abilene",
-        "namealt": null,
         "national": null,
         "pop_max": 114247,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2943,13 +2375,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 25.919980,
-        "longitude": -97.500002,
         "name": "Brownsville",
-        "namealt": null,
         "national": null,
         "pop_max": 181399,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2965,13 +2393,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.351086,
-        "longitude": -95.300783,
         "name": "Tyler",
-        "namealt": null,
         "national": null,
         "pop_max": 112245,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -2987,13 +2411,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.739977,
-        "longitude": -97.340038,
         "name": "Ft. Worth",
-        "namealt": "Fort Worth",
         "national": null,
         "pop_max": 1440454,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -3009,13 +2429,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 27.742814,
-        "longitude": -97.401895,
         "name": "Corpus Christi",
-        "namealt": null,
         "national": null,
         "pop_max": 277454,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -3031,13 +2447,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 30.266950,
-        "longitude": -97.742778,
         "name": "Austin",
-        "namealt": null,
         "national": null,
         "pop_max": 1161000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -3053,13 +2465,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 35.229980,
-        "longitude": -101.829997,
         "name": "Amarillo",
-        "namealt": null,
         "national": null,
         "pop_max": 181766,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -3075,13 +2483,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": "left",
-        "latitude": 31.779984,
-        "longitude": -106.509995,
         "name": "El Paso",
-        "namealt": null,
         "national": null,
         "pop_max": 753000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -3097,13 +2501,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 27.506136,
-        "longitude": -99.507218,
         "name": "Laredo",
-        "namealt": null,
         "national": null,
         "pop_max": 434768,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -3119,13 +2519,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": "bottom",
-        "latitude": 29.487333,
-        "longitude": -98.507305,
         "name": "San Antonio",
-        "namealt": null,
         "national": 1,
         "pop_max": 1473000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -3141,13 +2537,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 32.820024,
-        "longitude": -96.840017,
         "name": "Dallas",
-        "namealt": "Dallas-Fort Worth",
         "national": 1,
         "pop_max": 4798000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -3163,13 +2555,9 @@
       "properties": {
         "adm1name": "Texas",
         "align": null,
-        "latitude": 29.819974,
-        "longitude": -95.339979,
         "name": "Houston",
-        "namealt": null,
         "national": 1,
         "pop_max": 4459000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -3185,13 +2573,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 37.229419,
-        "longitude": -80.414198,
         "name": "Blacksburg",
-        "namealt": null,
         "national": null,
         "pop_max": 67508,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3207,13 +2591,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 38.449422,
-        "longitude": -78.869176,
         "name": "Harrisonburg",
-        "namealt": null,
         "national": null,
         "pop_max": 42538,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3229,13 +2609,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 37.227765,
-        "longitude": -77.402237,
         "name": "Petersburg",
-        "namealt": null,
         "national": null,
         "pop_max": 118577,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3251,13 +2627,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 37.030025,
-        "longitude": -76.349950,
         "name": "Hampton",
-        "namealt": null,
         "national": null,
         "pop_max": 366766,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3273,13 +2645,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 38.820433,
-        "longitude": -77.099982,
         "name": "Alexandria",
-        "namealt": null,
         "national": null,
         "pop_max": 127273,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3295,13 +2663,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 38.303513,
-        "longitude": -77.460786,
         "name": "Fredericksburg",
-        "namealt": null,
         "national": null,
         "pop_max": 133134,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3317,13 +2681,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 37.271199,
-        "longitude": -79.941617,
         "name": "Roanoke",
-        "namealt": null,
         "national": null,
         "pop_max": 198171,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3339,13 +2699,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 36.586254,
-        "longitude": -79.395319,
         "name": "Danville",
-        "namealt": null,
         "national": null,
         "pop_max": 45894,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3361,13 +2717,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 39.178731,
-        "longitude": -78.166635,
         "name": "Winchester",
-        "namealt": null,
         "national": null,
         "pop_max": 53941,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3383,13 +2735,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 36.611524,
-        "longitude": -82.176002,
         "name": "Bristol",
-        "namealt": null,
         "national": null,
         "pop_max": 37443,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3405,13 +2753,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 36.853214,
-        "longitude": -75.978319,
         "name": "Virginia Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 1491000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -3427,13 +2771,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 38.029189,
-        "longitude": -78.476926,
         "name": "Charlottesville",
-        "namealt": null,
         "national": null,
         "pop_max": 87925,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -3449,13 +2789,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": "right",
-        "latitude": 37.413619,
-        "longitude": -79.142467,
         "name": "Lynchburg",
-        "namealt": null,
         "national": null,
         "pop_max": 103893,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -3471,13 +2807,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 37.550019,
-        "longitude": -77.449986,
         "name": "Richmond",
-        "namealt": null,
         "national": null,
         "pop_max": 912000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -3493,13 +2825,9 @@
       "properties": {
         "adm1name": "Virginia",
         "align": null,
-        "latitude": 36.849959,
-        "longitude": -76.280006,
         "name": "Norfolk",
-        "namealt": null,
         "national": null,
         "pop_max": 1047869,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -3515,13 +2843,9 @@
       "properties": {
         "adm1name": "Maryland",
         "align": null,
-        "latitude": 38.603056,
-        "longitude": -76.938932,
         "name": "St. Charles",
-        "namealt": null,
         "national": null,
         "pop_max": 69208,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3537,13 +2861,9 @@
       "properties": {
         "adm1name": "Maryland",
         "align": null,
-        "latitude": 38.978330,
-        "longitude": -76.492499,
         "name": "Annapolis",
-        "namealt": null,
         "national": null,
         "pop_max": 81300,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -3559,13 +2879,9 @@
       "properties": {
         "adm1name": "Maryland",
         "align": null,
-        "latitude": 39.641649,
-        "longitude": -77.720280,
         "name": "Hagerstown",
-        "namealt": null,
         "national": null,
         "pop_max": 79662,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -3581,13 +2897,9 @@
       "properties": {
         "adm1name": "Maryland",
         "align": null,
-        "latitude": 39.653173,
-        "longitude": -78.762774,
         "name": "Cumberland",
-        "namealt": null,
         "national": null,
         "pop_max": 21316,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3603,13 +2915,9 @@
       "properties": {
         "adm1name": "Maryland",
         "align": null,
-        "latitude": 39.299990,
-        "longitude": -76.619985,
         "name": "Baltimore",
-        "namealt": null,
         "national": null,
         "pop_max": 2255000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -3625,13 +2933,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 42.535813,
-        "longitude": -113.791876,
         "name": "Burley",
-        "namealt": null,
         "national": null,
         "pop_max": 14042,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3647,13 +2951,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 47.474220,
-        "longitude": -115.926888,
         "name": "Wallace",
-        "namealt": null,
         "national": null,
         "pop_max": 1028,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3669,13 +2969,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 42.322622,
-        "longitude": -111.296912,
         "name": "Montpelier",
-        "namealt": null,
         "national": null,
         "pop_max": 2997,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3691,13 +2987,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 42.560954,
-        "longitude": -114.460569,
         "name": "Twin Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 47315,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3713,13 +3005,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 43.660964,
-        "longitude": -116.670538,
         "name": "Caldwell",
-        "namealt": null,
         "national": null,
         "pop_max": 132476,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3735,13 +3023,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 45.175678,
-        "longitude": -113.894997,
         "name": "Salmon",
-        "namealt": null,
         "national": null,
         "pop_max": 3601,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3757,13 +3041,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 47.678083,
-        "longitude": -116.779446,
         "name": "Coeur d'Alene",
-        "namealt": null,
         "national": null,
         "pop_max": 34514,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3779,13 +3059,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 42.871348,
-        "longitude": -112.444723,
         "name": "Pocatello",
-        "namealt": null,
         "national": null,
         "pop_max": 63998,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -3801,13 +3077,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 43.466687,
-        "longitude": -112.033301,
         "name": "Idaho Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 79399,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -3823,13 +3095,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 46.416610,
-        "longitude": -117.016589,
         "name": "Lewiston",
-        "namealt": null,
         "national": null,
         "pop_max": 49289,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -3845,13 +3113,9 @@
       "properties": {
         "adm1name": "Idaho",
         "align": null,
-        "latitude": 43.608590,
-        "longitude": -116.227490,
         "name": "Boise",
-        "namealt": null,
         "national": null,
         "pop_max": 338071,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -3867,13 +3131,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 36.865487,
-        "longitude": -87.488624,
         "name": "Hopkinsville",
-        "namealt": null,
         "national": null,
         "pop_max": 35604,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3889,13 +3149,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 37.128882,
-        "longitude": -84.083354,
         "name": "London",
-        "namealt": null,
         "national": null,
         "pop_max": 7844,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3911,13 +3167,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 37.332746,
-        "longitude": -87.502215,
         "name": "Madisonville",
-        "namealt": null,
         "national": null,
         "pop_max": 22294,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -3933,13 +3185,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 39.084008,
-        "longitude": -84.508599,
         "name": "Covington",
-        "namealt": null,
         "national": null,
         "pop_max": 585489,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3955,13 +3203,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 36.990699,
-        "longitude": -86.443649,
         "name": "Bowling Green",
-        "namealt": null,
         "national": null,
         "pop_max": 71140,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -3977,13 +3221,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 37.083717,
-        "longitude": -88.600003,
         "name": "Paducah",
-        "namealt": null,
         "national": null,
         "pop_max": 41317,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -3999,13 +3239,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 37.774579,
-        "longitude": -87.113324,
         "name": "Owensboro",
-        "namealt": null,
         "national": null,
         "pop_max": 67825,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4021,14 +3257,10 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 38.200806,
-        "longitude": -84.873357,
         "name": "Frankfort",
-        "namealt": null,
         "national": null,
         "pop_max": 36688,
-        "scalerank": 6,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -4042,14 +3274,10 @@
       },
       "properties": {
         "adm1name": "Kentucky",
-        "align": "bottom",
-        "latitude": 38.225017,
-        "longitude": -85.748704,
+        "align": null,
         "name": "Louisville",
-        "namealt": null,
         "national": null,
         "pop_max": 948000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -4065,13 +3293,9 @@
       "properties": {
         "adm1name": "Kentucky",
         "align": null,
-        "latitude": 38.050015,
-        "longitude": -84.500021,
         "name": "Lexington",
-        "namealt": null,
         "national": null,
         "pop_max": 264578,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -4087,13 +3311,9 @@
       "properties": {
         "adm1name": "New Jersey",
         "align": null,
-        "latitude": 40.919995,
-        "longitude": -74.170005,
         "name": "Paterson",
-        "namealt": null,
         "national": null,
         "pop_max": 151205,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4109,35 +3329,9 @@
       "properties": {
         "adm1name": "New Jersey",
         "align": null,
-        "latitude": 39.364637,
-        "longitude": -74.423323,
         "name": "Atlantic City",
-        "namealt": null,
         "national": null,
         "pop_max": 76573,
-        "scalerank": 7,
-        "visible": 1
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          -74.170005332114897,
-          40.700421365413604
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "adm1name": "New Jersey",
-        "align": "right",
-        "latitude": 40.700421,
-        "longitude": -74.170005,
-        "name": "Newark",
-        "namealt": null,
-        "national": null,
-        "pop_max": 280123,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -4153,13 +3347,9 @@
       "properties": {
         "adm1name": "New Jersey",
         "align": null,
-        "latitude": 40.216963,
-        "longitude": -74.743355,
         "name": "Trenton",
-        "namealt": null,
         "national": null,
         "pop_max": 366513,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -4175,13 +3365,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.747200,
-        "longitude": -95.980586,
         "name": "Bartlesville",
-        "namealt": null,
         "national": null,
         "pop_max": 34610,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4197,13 +3383,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.395542,
-        "longitude": -97.878093,
         "name": "Enid",
-        "namealt": null,
         "national": null,
         "pop_max": 46138,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4219,13 +3401,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 34.181078,
-        "longitude": -97.129405,
         "name": "Ardmore",
-        "namealt": null,
         "national": null,
         "pop_max": 24960,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4241,13 +3419,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 34.932996,
-        "longitude": -95.765974,
         "name": "McAlester",
-        "namealt": null,
         "national": null,
         "pop_max": 21668,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4263,13 +3437,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.135351,
-        "longitude": -97.068298,
         "name": "Stillwater",
-        "namealt": null,
         "national": null,
         "pop_max": 47667,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4285,13 +3455,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 34.599037,
-        "longitude": -98.409973,
         "name": "Lawton",
-        "namealt": null,
         "national": null,
         "pop_max": 91752,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4307,13 +3473,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 35.227913,
-        "longitude": -97.344146,
         "name": "Norman",
-        "namealt": null,
         "national": null,
         "pop_max": 113525,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4329,13 +3491,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 35.748217,
-        "longitude": -95.369435,
         "name": "Muskogee",
-        "namealt": null,
         "national": null,
         "pop_max": 39295,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4351,13 +3509,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.707358,
-        "longitude": -97.085273,
         "name": "Ponca City",
-        "namealt": null,
         "national": null,
         "pop_max": 25273,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4373,13 +3527,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 35.342790,
-        "longitude": -96.933784,
         "name": "Shawnee",
-        "namealt": null,
         "national": null,
         "pop_max": 29628,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4395,13 +3545,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.433421,
-        "longitude": -99.397690,
         "name": "Woodward",
-        "namealt": null,
         "national": null,
         "pop_max": 12931,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4417,13 +3563,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.685809,
-        "longitude": -101.479501,
         "name": "Guymon",
-        "namealt": null,
         "national": null,
         "pop_max": 11178,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4439,13 +3581,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": null,
-        "latitude": 36.120003,
-        "longitude": -95.930021,
         "name": "Tulsa",
-        "namealt": null,
         "national": null,
         "pop_max": 946962,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -4461,13 +3599,9 @@
       "properties": {
         "adm1name": "Oklahoma",
         "align": "bottom",
-        "latitude": 35.470043,
-        "longitude": -97.518684,
         "name": "Oklahoma City",
-        "namealt": null,
         "national": null,
         "pop_max": 788000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -4483,13 +3617,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 36.057087,
-        "longitude": -90.502884,
         "name": "Paragould",
-        "namealt": null,
         "national": null,
         "pop_max": 23450,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4505,13 +3635,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 35.842578,
-        "longitude": -90.704164,
         "name": "Jonesboro",
-        "namealt": null,
         "national": null,
         "pop_max": 58619,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4526,14 +3652,10 @@
       },
       "properties": {
         "adm1name": "Arkansas",
-        "align": "right",
-        "latitude": 33.442105,
-        "longitude": -94.037475,
+        "align": "left",
         "name": "Texarkana",
-        "namealt": null,
         "national": null,
         "pop_max": 74414,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -4549,13 +3671,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 34.228698,
-        "longitude": -92.003051,
         "name": "Pine Bluff",
-        "namealt": null,
         "national": null,
         "pop_max": 53217,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4571,13 +3689,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 34.503952,
-        "longitude": -93.055002,
         "name": "Hot Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 44182,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4593,13 +3707,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 35.386224,
-        "longitude": -94.398357,
         "name": "Fort Smith",
-        "namealt": null,
         "national": null,
         "pop_max": 93988,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4615,13 +3725,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 36.062978,
-        "longitude": -94.157209,
         "name": "Fayetteville",
-        "namealt": null,
         "national": null,
         "pop_max": 151671,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -4637,13 +3743,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 35.091281,
-        "longitude": -92.451318,
         "name": "Conway",
-        "namealt": null,
         "national": null,
         "pop_max": 61995,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4659,13 +3761,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": null,
-        "latitude": 33.213927,
-        "longitude": -92.662520,
         "name": "El Dorado",
-        "namealt": null,
         "national": null,
         "pop_max": 22416,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4681,13 +3779,9 @@
       "properties": {
         "adm1name": "Arkansas",
         "align": "bottom",
-        "latitude": 34.736083,
-        "longitude": -92.331093,
         "name": "Little Rock",
-        "namealt": null,
         "national": null,
         "pop_max": 270893,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -4703,13 +3797,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 38.065492,
-        "longitude": -97.923491,
         "name": "Hutchinson",
-        "namealt": null,
         "national": null,
         "pop_max": 44477,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4725,13 +3815,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 39.113581,
-        "longitude": -94.630146,
         "name": "Kansas City",
-        "namealt": null,
         "national": null,
         "pop_max": 501577,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4747,13 +3833,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 38.959752,
-        "longitude": -95.255230,
         "name": "Lawrence",
-        "namealt": null,
         "national": null,
         "pop_max": 92726,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4769,13 +3851,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 37.975213,
-        "longitude": -100.864087,
         "name": "Garden City",
-        "namealt": null,
         "national": null,
         "pop_max": 28564,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4791,13 +3869,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 39.194028,
-        "longitude": -96.592435,
         "name": "Manhattan",
-        "namealt": null,
         "national": null,
         "pop_max": 56949,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4813,13 +3887,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 38.879370,
-        "longitude": -99.322191,
         "name": "Hays",
-        "namealt": null,
         "national": null,
         "pop_max": 21394,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4835,13 +3905,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 39.348488,
-        "longitude": -101.711037,
         "name": "Goodland",
-        "namealt": null,
         "national": null,
         "pop_max": 4378,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -4857,13 +3923,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 38.404231,
-        "longitude": -96.181375,
         "name": "Emporia",
-        "namealt": null,
         "national": null,
         "pop_max": 29048,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4879,13 +3941,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 38.824670,
-        "longitude": -97.607179,
         "name": "Salina",
-        "namealt": null,
         "national": null,
         "pop_max": 48031,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4901,13 +3959,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 37.760058,
-        "longitude": -100.018195,
         "name": "Dodge City",
-        "namealt": null,
         "national": null,
         "pop_max": 25932,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4923,13 +3977,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 37.038061,
-        "longitude": -95.626318,
         "name": "Coffeyville",
-        "namealt": null,
         "national": null,
         "pop_max": 11760,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -4945,13 +3995,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 37.719983,
-        "longitude": -97.329987,
         "name": "Wichita",
-        "namealt": null,
         "national": null,
         "pop_max": 401843,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -4967,13 +4013,9 @@
       "properties": {
         "adm1name": "Kansas",
         "align": null,
-        "latitude": 39.050005,
-        "longitude": -95.669985,
         "name": "Topeka",
-        "namealt": null,
         "national": null,
         "pop_max": 132091,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -4989,13 +4031,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 40.700706,
-        "longitude": -99.081146,
         "name": "Kearney",
-        "namealt": null,
         "national": null,
         "pop_max": 31553,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5011,13 +4049,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 40.922268,
-        "longitude": -98.357986,
         "name": "Grand Island",
-        "namealt": null,
         "national": null,
         "pop_max": 45651,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5033,13 +4067,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 42.101395,
-        "longitude": -102.870191,
         "name": "Alliance",
-        "namealt": null,
         "national": null,
         "pop_max": 8344,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5055,13 +4085,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 40.205594,
-        "longitude": -100.626168,
         "name": "McCook",
-        "namealt": null,
         "national": null,
         "pop_max": 8012,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5077,13 +4103,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 42.028712,
-        "longitude": -97.433598,
         "name": "Norfolk",
-        "namealt": null,
         "national": null,
         "pop_max": 25030,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5099,13 +4121,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 41.136286,
-        "longitude": -100.770501,
         "name": "North Platte",
-        "namealt": null,
         "national": null,
         "pop_max": 25247,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5121,13 +4139,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 41.139800,
-        "longitude": -102.978273,
         "name": "Sidney",
-        "namealt": null,
         "national": null,
         "pop_max": 6492,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5143,13 +4157,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 41.867508,
-        "longitude": -103.660686,
         "name": "Scottsbluff",
-        "namealt": null,
         "national": null,
         "pop_max": 25475,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5165,13 +4175,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 42.827914,
-        "longitude": -103.003077,
         "name": "Chadron",
-        "namealt": null,
         "national": null,
         "pop_max": 5798,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5187,13 +4193,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 40.819975,
-        "longitude": -96.680001,
         "name": "Lincoln",
-        "namealt": null,
         "national": null,
         "pop_max": 246220,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -5209,13 +4211,9 @@
       "properties": {
         "adm1name": "Nebraska",
         "align": null,
-        "latitude": 41.240001,
-        "longitude": -96.009990,
         "name": "Omaha",
-        "namealt": null,
         "national": null,
         "pop_max": 877110,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -5231,13 +4229,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.290486,
-        "longitude": -93.268013,
         "name": "Faribault",
-        "namealt": null,
         "national": null,
         "pop_max": 25376,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5253,13 +4247,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.163621,
-        "longitude": -93.999157,
         "name": "Mankato",
-        "namealt": null,
         "national": null,
         "pop_max": 56325,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5275,13 +4265,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 43.647787,
-        "longitude": -93.368704,
         "name": "Albert Lea",
-        "namealt": null,
         "national": null,
         "pop_max": 20522,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5297,13 +4283,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 45.121883,
-        "longitude": -95.043305,
         "name": "Willmar",
-        "namealt": null,
         "national": null,
         "pop_max": 18473,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5319,13 +4301,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 46.358009,
-        "longitude": -94.200850,
         "name": "Brainerd",
-        "namealt": null,
         "national": null,
         "pop_max": 28187,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5341,13 +4319,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 47.773762,
-        "longitude": -96.607731,
         "name": "Crookston",
-        "namealt": null,
         "national": null,
         "pop_max": 8653,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5363,13 +4337,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 47.523674,
-        "longitude": -92.536404,
         "name": "Virginia",
-        "namealt": null,
         "national": null,
         "pop_max": 8709,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5385,13 +4355,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.050424,
-        "longitude": -91.639197,
         "name": "Winona",
-        "namealt": null,
         "national": null,
         "pop_max": 32897,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5407,13 +4373,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.022053,
-        "longitude": -92.469689,
         "name": "Rochester",
-        "namealt": null,
         "national": null,
         "pop_max": 108511,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -5429,13 +4391,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.650103,
-        "longitude": -93.242510,
         "name": "Lakeville",
-        "namealt": null,
         "national": null,
         "pop_max": 261308,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5451,13 +4409,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 47.900421,
-        "longitude": -91.825698,
         "name": "Ely",
-        "namealt": null,
         "national": null,
         "pop_max": 3731,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5473,13 +4427,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 46.874308,
-        "longitude": -96.742193,
         "name": "Moorhead",
-        "namealt": null,
         "national": null,
         "pop_max": 35528,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5495,13 +4445,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 45.561210,
-        "longitude": -94.162222,
         "name": "St. Cloud",
-        "namealt": null,
         "national": null,
         "pop_max": 112794,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5517,13 +4463,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 46.783332,
-        "longitude": -92.106378,
         "name": "Duluth",
-        "namealt": null,
         "national": null,
         "pop_max": 84800,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -5539,13 +4481,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 47.473574,
-        "longitude": -94.880188,
         "name": "Bemidji",
-        "namealt": null,
         "national": null,
         "pop_max": 14796,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -5561,13 +4499,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 48.601128,
-        "longitude": -93.410846,
         "name": "International Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 15240,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -5583,13 +4517,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.943987,
-        "longitude": -93.084975,
         "name": "St. Paul",
-        "namealt": "Saint Paul",
         "national": null,
         "pop_max": 734854,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -5605,13 +4535,9 @@
       "properties": {
         "adm1name": "Minnesota",
         "align": null,
-        "latitude": 44.979979,
-        "longitude": -93.251786,
         "name": "Minneapolis",
-        "namealt": "Minneapolis-St. Paul",
         "national": 1,
         "pop_max": 2616000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -5627,13 +4553,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 36.313325,
-        "longitude": -82.353614,
         "name": "Johnson City",
-        "namealt": null,
         "national": null,
         "pop_max": 77538,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5649,13 +4571,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 36.548323,
-        "longitude": -82.561948,
         "name": "Kingsport",
-        "namealt": null,
         "national": null,
         "pop_max": 57467,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5671,13 +4589,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.614995,
-        "longitude": -87.035267,
         "name": "Columbia",
-        "namealt": null,
         "national": null,
         "pop_max": 116091,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5693,13 +4607,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.222900,
-        "longitude": -89.841090,
         "name": "Barlett",
-        "namealt": null,
         "national": null,
         "pop_max": 286423,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5715,13 +4625,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 36.010656,
-        "longitude": -84.269725,
         "name": "Oak Ridge",
-        "namealt": null,
         "national": null,
         "pop_max": 33556,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5737,13 +4643,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.845963,
-        "longitude": -86.390267,
         "name": "Murfreesboro",
-        "namealt": null,
         "national": null,
         "pop_max": 115774,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5759,13 +4661,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 36.530082,
-        "longitude": -87.359433,
         "name": "Clarksville",
-        "namealt": null,
         "national": null,
         "pop_max": 132536,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -5781,14 +4679,10 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.614866,
-        "longitude": -88.813892,
         "name": "Jackson",
-        "namealt": null,
         "national": null,
         "pop_max": 63196,
-        "scalerank": 7,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -5803,13 +4697,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.069990,
-        "longitude": -85.250001,
         "name": "Chattanooga",
-        "namealt": null,
         "national": null,
         "pop_max": 257589,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -5825,13 +4715,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 35.970012,
-        "longitude": -83.920030,
         "name": "Knoxville",
-        "namealt": null,
         "national": null,
         "pop_max": 655400,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -5847,13 +4733,9 @@
       "properties": {
         "adm1name": "Tennessee",
         "align": null,
-        "latitude": 36.169974,
-        "longitude": -86.779985,
         "name": "Nashville",
-        "namealt": "Nashville-Davidson",
         "national": null,
         "pop_max": 877000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -5868,14 +4750,10 @@
       },
       "properties": {
         "adm1name": "Tennessee",
-        "align": "right",
-        "latitude": 35.119987,
-        "longitude": -89.999995,
+        "align": "left",
         "name": "Memphis",
-        "namealt": null,
         "national": null,
         "pop_max": 1081000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -5891,13 +4769,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 39.940287,
-        "longitude": -82.013325,
         "name": "Zanesville",
-        "namealt": null,
         "national": null,
         "pop_max": 40052,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5913,13 +4787,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 40.758325,
-        "longitude": -82.515542,
         "name": "Mansfield",
-        "namealt": null,
         "national": null,
         "pop_max": 77768,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5935,13 +4805,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 41.374747,
-        "longitude": -83.651390,
         "name": "Bowling Green",
-        "namealt": null,
         "national": null,
         "pop_max": 37080,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -5956,15 +4822,11 @@
       },
       "properties": {
         "adm1name": "Ohio",
-        "align": null,
-        "latitude": 39.920004,
-        "longitude": -83.799986,
+        "align": "right",
         "name": "Springfield",
-        "namealt": null,
         "national": null,
         "pop_max": 84576,
-        "scalerank": 8,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -5979,13 +4841,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 39.719215,
-        "longitude": -82.605304,
         "name": "Lancaster",
-        "namealt": null,
         "national": null,
         "pop_max": 48829,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6001,13 +4859,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 41.070399,
-        "longitude": -81.519996,
         "name": "Akron",
-        "namealt": null,
         "national": null,
         "pop_max": 703200,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6023,13 +4877,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 40.742874,
-        "longitude": -84.105265,
         "name": "Lima",
-        "namealt": null,
         "national": null,
         "pop_max": 68364,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6045,13 +4895,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 39.750376,
-        "longitude": -84.199987,
         "name": "Dayton",
-        "namealt": null,
         "national": null,
         "pop_max": 773000,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -6067,13 +4913,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 41.099699,
-        "longitude": -80.649739,
         "name": "Youngstown",
-        "namealt": null,
         "national": null,
         "pop_max": 311990,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -6089,13 +4931,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 40.798865,
-        "longitude": -81.378635,
         "name": "Canton",
-        "namealt": null,
         "national": null,
         "pop_max": 258660,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -6111,13 +4949,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 41.670026,
-        "longitude": -83.579974,
         "name": "Toledo",
-        "namealt": null,
         "national": null,
         "pop_max": 469924,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -6133,13 +4967,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": "bottom",
-        "latitude": 39.979974,
-        "longitude": -82.990010,
         "name": "Columbus",
-        "namealt": "Columbus, Ohio",
         "national": null,
         "pop_max": 1270000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -6155,13 +4985,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 41.469987,
-        "longitude": -81.694998,
         "name": "Cleveland",
-        "namealt": null,
         "national": null,
         "pop_max": 1890000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -6177,13 +5003,9 @@
       "properties": {
         "adm1name": "Ohio",
         "align": null,
-        "latitude": 39.161885,
-        "longitude": -84.456923,
         "name": "Cincinnati",
-        "namealt": null,
         "national": null,
         "pop_max": 1636000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -6199,13 +5021,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 39.266659,
-        "longitude": -81.561647,
         "name": "Parkersburg",
-        "namealt": null,
         "national": null,
         "pop_max": 61935,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6221,13 +5039,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 37.793880,
-        "longitude": -80.303481,
         "name": "White Sulphur Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 2407,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6243,13 +5057,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 39.283273,
-        "longitude": -80.336916,
         "name": "Clarksburg",
-        "namealt": null,
         "national": null,
         "pop_max": 28773,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6265,13 +5075,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 40.064310,
-        "longitude": -80.721078,
         "name": "Wheeling",
-        "namealt": null,
         "national": null,
         "pop_max": 52492,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -6287,13 +5093,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 39.629815,
-        "longitude": -79.956060,
         "name": "Morgantown",
-        "namealt": null,
         "national": null,
         "pop_max": 58808,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6309,13 +5111,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": "bottom",
-        "latitude": 38.419579,
-        "longitude": -82.445288,
         "name": "Huntington",
-        "namealt": null,
         "national": null,
         "pop_max": 85396,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -6331,13 +5129,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 37.780186,
-        "longitude": -81.183014,
         "name": "Beckley",
-        "namealt": null,
         "national": null,
         "pop_max": 37836,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6353,13 +5147,9 @@
       "properties": {
         "adm1name": "West Virginia",
         "align": null,
-        "latitude": 38.349738,
-        "longitude": -81.632728,
         "name": "Charleston",
-        "namealt": null,
         "national": null,
         "pop_max": 123799,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -6375,13 +5165,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 38.772477,
-        "longitude": -112.083298,
         "name": "Richfield",
-        "namealt": null,
         "national": null,
         "pop_max": 7621,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6397,13 +5183,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 39.710275,
-        "longitude": -111.835484,
         "name": "Nephi",
-        "namealt": null,
         "national": null,
         "pop_max": 5117,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6419,13 +5201,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 41.735940,
-        "longitude": -111.833598,
         "name": "Logan",
-        "namealt": null,
         "national": null,
         "pop_max": 72490,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6441,13 +5219,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 37.842534,
-        "longitude": -112.827206,
         "name": "Parowan",
-        "namealt": null,
         "national": null,
         "pop_max": 2571,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6463,13 +5237,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 37.047389,
-        "longitude": -112.525494,
         "name": "Kanab",
-        "namealt": null,
         "national": null,
         "pop_max": 3442,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6485,13 +5255,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 37.871783,
-        "longitude": -109.342200,
         "name": "Monticello",
-        "namealt": null,
         "national": null,
         "pop_max": 1864,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6507,13 +5273,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 38.573704,
-        "longitude": -109.549189,
         "name": "Moab",
-        "namealt": null,
         "national": null,
         "pop_max": 5730,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6529,13 +5291,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 39.599791,
-        "longitude": -110.810017,
         "name": "Price",
-        "namealt": null,
         "national": null,
         "pop_max": 10281,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6551,13 +5309,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 37.677428,
-        "longitude": -113.061094,
         "name": "Cedar City",
-        "namealt": null,
         "national": null,
         "pop_max": 27738,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6573,13 +5327,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 40.455398,
-        "longitude": -109.528002,
         "name": "Vernal",
-        "namealt": null,
         "national": null,
         "pop_max": 14353,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6595,13 +5345,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 41.232379,
-        "longitude": -111.968034,
         "name": "Ogden",
-        "namealt": null,
         "national": null,
         "pop_max": 377224,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6617,13 +5363,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 37.104155,
-        "longitude": -113.583336,
         "name": "St. George",
-        "namealt": null,
         "national": null,
         "pop_max": 98638,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -6639,13 +5381,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 40.248899,
-        "longitude": -111.637770,
         "name": "Provo",
-        "namealt": null,
         "national": null,
         "pop_max": 356712,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -6661,13 +5399,9 @@
       "properties": {
         "adm1name": "Utah",
         "align": null,
-        "latitude": 40.775016,
-        "longitude": -111.930052,
         "name": "Salt Lake City",
-        "namealt": null,
         "national": null,
         "pop_max": 966000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -6683,13 +5417,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 44.350845,
-        "longitude": -103.765770,
         "name": "Lead",
-        "namealt": null,
         "national": null,
         "pop_max": 2874,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6705,13 +5435,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 42.882019,
-        "longitude": -97.392490,
         "name": "Yankton",
-        "namealt": null,
         "national": null,
         "pop_max": 15580,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6727,13 +5453,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 44.306765,
-        "longitude": -96.788030,
         "name": "Brookings",
-        "namealt": null,
         "national": null,
         "pop_max": 22411,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6749,13 +5471,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 43.714294,
-        "longitude": -98.026198,
         "name": "Mitchell",
-        "namealt": null,
         "national": null,
         "pop_max": 15205,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6771,13 +5489,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 45.465118,
-        "longitude": -98.486402,
         "name": "Aberdeen",
-        "namealt": null,
         "national": null,
         "pop_max": 26041,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -6793,13 +5507,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 45.540126,
-        "longitude": -100.434707,
         "name": "Mobridge",
-        "namealt": null,
         "national": null,
         "pop_max": 3156,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6815,13 +5525,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 44.080551,
-        "longitude": -103.230557,
         "name": "Rapid City",
-        "namealt": null,
         "national": null,
         "pop_max": 73632,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -6837,13 +5543,9 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 43.549989,
-        "longitude": -96.729998,
         "name": "Sioux Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 155724,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -6859,14 +5561,10 @@
       "properties": {
         "adm1name": "South Dakota",
         "align": null,
-        "latitude": 44.368337,
-        "longitude": -100.350552,
         "name": "Pierre",
-        "namealt": null,
         "national": null,
         "pop_max": 13879,
-        "scalerank": 3,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -6881,13 +5579,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 32.261092,
-        "longitude": -107.755785,
         "name": "Deming",
-        "namealt": null,
         "national": null,
         "pop_max": 16298,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6903,13 +5597,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 33.133596,
-        "longitude": -107.252896,
         "name": "Truth or Consequences",
-        "namealt": null,
         "national": null,
         "pop_max": 7121,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6925,13 +5615,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.597012,
-        "longitude": -105.222503,
         "name": "Las Vegas",
-        "namealt": null,
         "national": null,
         "pop_max": 16998,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6947,13 +5633,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 36.754151,
-        "longitude": -108.186094,
         "name": "Farmington",
-        "namealt": null,
         "national": null,
         "pop_max": 43278,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -6969,13 +5651,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 33.394537,
-        "longitude": -104.522468,
         "name": "Roswell",
-        "namealt": null,
         "national": null,
         "pop_max": 46096,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -6991,13 +5669,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 34.405069,
-        "longitude": -103.204771,
         "name": "Clovis",
-        "namealt": null,
         "national": null,
         "pop_max": 33792,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7013,13 +5687,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 32.312613,
-        "longitude": -106.777808,
         "name": "Las Cruces",
-        "namealt": null,
         "national": null,
         "pop_max": 115167,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -7035,13 +5705,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 32.712614,
-        "longitude": -103.140614,
         "name": "Hobbs",
-        "namealt": null,
         "national": null,
         "pop_max": 28738,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7057,13 +5723,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 34.062119,
-        "longitude": -106.898990,
         "name": "Socorro",
-        "namealt": null,
         "national": null,
         "pop_max": 8668,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7079,13 +5741,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.524071,
-        "longitude": -108.733994,
         "name": "Gallup",
-        "namealt": null,
         "national": null,
         "pop_max": 23800,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7101,13 +5759,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 36.897398,
-        "longitude": -104.439889,
         "name": "Raton",
-        "namealt": null,
         "national": null,
         "pop_max": 7073,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7123,13 +5777,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.169803,
-        "longitude": -103.725514,
         "name": "Tucumcari",
-        "namealt": null,
         "national": null,
         "pop_max": 5313,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7145,13 +5795,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 32.420565,
-        "longitude": -104.228300,
         "name": "Carlsbad",
-        "namealt": null,
         "national": null,
         "pop_max": 25302,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -7167,13 +5813,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 32.899476,
-        "longitude": -105.959719,
         "name": "Alamogordo",
-        "namealt": null,
         "national": null,
         "pop_max": 36058,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -7189,13 +5831,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.891103,
-        "longitude": -106.297708,
         "name": "Los Alamos",
-        "namealt": null,
         "national": null,
         "pop_max": 12233,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -7211,13 +5849,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.104975,
-        "longitude": -106.641331,
         "name": "Albuquerque",
-        "namealt": null,
         "national": null,
         "pop_max": 898642,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -7233,13 +5867,9 @@
       "properties": {
         "adm1name": "New Mexico",
         "align": null,
-        "latitude": 35.686929,
-        "longitude": -105.937239,
         "name": "Santa Fe",
-        "namealt": null,
         "national": null,
         "pop_max": 92681,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -7255,13 +5885,9 @@
       "properties": {
         "adm1name": "Rhode Island",
         "align": "bottom",
-        "latitude": 41.490399,
-        "longitude": -71.313358,
         "name": "Newport",
-        "namealt": null,
         "national": null,
         "pop_max": 45968,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -7277,13 +5903,9 @@
       "properties": {
         "adm1name": "Rhode Island",
         "align": null,
-        "latitude": 41.821102,
-        "longitude": -71.414980,
         "name": "Providence",
-        "namealt": null,
         "national": null,
         "pop_max": 1277000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -7299,13 +5921,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.355523,
-        "longitude": -72.100028,
         "name": "New London",
-        "namealt": null,
         "national": null,
         "pop_max": 96178,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7321,13 +5939,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.053346,
-        "longitude": -73.539191,
         "name": "Stamford",
-        "namealt": null,
         "national": null,
         "pop_max": 746920,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7343,13 +5957,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.550008,
-        "longitude": -73.050022,
         "name": "Waterbury",
-        "namealt": null,
         "national": null,
         "pop_max": 174236,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7365,13 +5975,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.330383,
-        "longitude": -72.900005,
         "name": "New Haven",
-        "namealt": null,
         "national": null,
         "pop_max": 846766,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7387,13 +5993,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.770020,
-        "longitude": -72.679967,
         "name": "Hartford",
-        "namealt": null,
         "national": null,
         "pop_max": 913000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -7409,13 +6011,9 @@
       "properties": {
         "adm1name": "Connecticut",
         "align": null,
-        "latitude": 41.179979,
-        "longitude": -73.199961,
         "name": "Bridgeport",
-        "namealt": "Bridgeport-Stamford",
         "national": null,
         "pop_max": 1018000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -7431,13 +6029,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 41.661086,
-        "longitude": -91.529979,
         "name": "Iowa City",
-        "namealt": null,
         "national": null,
         "pop_max": 98516,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7453,13 +6047,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 41.012883,
-        "longitude": -92.414809,
         "name": "Ottumwa",
-        "namealt": null,
         "national": null,
         "pop_max": 25982,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7475,13 +6065,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 43.145285,
-        "longitude": -95.147175,
         "name": "Spencer",
-        "namealt": null,
         "national": null,
         "pop_max": 11203,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7497,13 +6083,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 42.506823,
-        "longitude": -94.180257,
         "name": "Ft. Dodge",
-        "namealt": "Fort Dodge",
         "national": null,
         "pop_max": 26879,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7519,13 +6101,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 41.553987,
-        "longitude": -90.587530,
         "name": "Davenport",
-        "namealt": null,
         "national": null,
         "pop_max": 255738,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -7541,13 +6119,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 40.807934,
-        "longitude": -91.112770,
         "name": "Burlington",
-        "namealt": null,
         "national": null,
         "pop_max": 29773,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7563,13 +6137,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 42.500932,
-        "longitude": -90.664451,
         "name": "Dubuque",
-        "namealt": null,
         "national": null,
         "pop_max": 62483,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7585,13 +6155,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 42.493154,
-        "longitude": -92.342798,
         "name": "Waterloo",
-        "namealt": null,
         "national": null,
         "pop_max": 98347,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7607,13 +6173,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 42.500389,
-        "longitude": -96.399992,
         "name": "Sioux City",
-        "namealt": null,
         "national": null,
         "pop_max": 90932,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7629,13 +6191,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 41.262273,
-        "longitude": -95.860800,
         "name": "Council Bluffs",
-        "namealt": null,
         "national": null,
         "pop_max": 101805,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7651,13 +6209,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 42.053853,
-        "longitude": -93.619723,
         "name": "Ames",
-        "namealt": null,
         "national": null,
         "pop_max": 57104,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7673,13 +6227,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 43.154018,
-        "longitude": -93.200833,
         "name": "Mason City",
-        "namealt": null,
         "national": null,
         "pop_max": 27802,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7694,14 +6244,10 @@
       },
       "properties": {
         "adm1name": "Iowa",
-        "align": "left",
-        "latitude": 41.969982,
-        "longitude": -91.660023,
+        "align": null,
         "name": "Cedar Rapids",
-        "namealt": null,
         "national": null,
         "pop_max": 170621,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -7717,13 +6263,9 @@
       "properties": {
         "adm1name": "Iowa",
         "align": null,
-        "latitude": 41.579980,
-        "longitude": -93.619981,
         "name": "Des Moines",
-        "namealt": null,
         "national": null,
         "pop_max": 380655,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -7739,13 +6281,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 30.274960,
-        "longitude": -89.781094,
         "name": "Slidell",
-        "namealt": null,
         "national": null,
         "pop_max": 84239,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7761,13 +6299,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 30.226384,
-        "longitude": -93.217189,
         "name": "Lake Charles",
-        "namealt": null,
         "national": null,
         "pop_max": 83821,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7783,13 +6317,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 29.983866,
-        "longitude": -90.152777,
         "name": "Metairie",
-        "namealt": null,
         "national": null,
         "pop_max": 394206,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7805,13 +6335,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 30.003581,
-        "longitude": -91.818308,
         "name": "New Iberia",
-        "namealt": null,
         "national": null,
         "pop_max": 37540,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -7827,13 +6353,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 29.595931,
-        "longitude": -90.719486,
         "name": "Houma",
-        "namealt": null,
         "national": null,
         "pop_max": 64592,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7849,13 +6371,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 32.509603,
-        "longitude": -92.119194,
         "name": "Monroe",
-        "namealt": null,
         "national": null,
         "pop_max": 101724,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -7871,13 +6389,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 30.199977,
-        "longitude": -92.019949,
         "name": "Lafayette",
-        "namealt": null,
         "national": null,
         "pop_max": 158214,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -7893,13 +6407,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 31.311098,
-        "longitude": -92.445014,
         "name": "Alexandria",
-        "namealt": null,
         "national": null,
         "pop_max": 76565,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -7915,13 +6425,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 32.500018,
-        "longitude": -93.770023,
         "name": "Shreveport",
-        "namealt": null,
         "national": null,
         "pop_max": 248053,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -7937,13 +6443,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 30.457946,
-        "longitude": -91.140158,
         "name": "Baton Rouge",
-        "namealt": null,
         "national": null,
         "pop_max": 422072,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -7959,13 +6461,9 @@
       "properties": {
         "adm1name": "Louisiana",
         "align": null,
-        "latitude": 29.995002,
-        "longitude": -90.039967,
         "name": "New Orleans",
-        "namealt": null,
         "national": null,
         "pop_max": 785000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -7981,13 +6479,9 @@
       "properties": {
         "adm1name": "Delaware",
         "align": null,
-        "latitude": 39.158087,
-        "longitude": -75.524703,
         "name": "Dover",
-        "namealt": null,
         "national": null,
         "pop_max": 76039,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -8003,13 +6497,9 @@
       "properties": {
         "adm1name": "Delaware",
         "align": null,
-        "latitude": 39.746268,
-        "longitude": -75.546898,
         "name": "Wilmington",
-        "namealt": null,
         "national": null,
         "pop_max": 161560,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -8025,13 +6515,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 32.609701,
-        "longitude": -85.480839,
         "name": "Auburn",
-        "namealt": null,
         "national": null,
         "pop_max": 73929,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8047,13 +6533,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 34.799696,
-        "longitude": -87.677243,
         "name": "Florence",
-        "namealt": null,
         "national": null,
         "pop_max": 45349,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8069,13 +6551,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 31.223455,
-        "longitude": -85.390587,
         "name": "Dothan",
-        "namealt": null,
         "national": null,
         "pop_max": 61741,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8091,13 +6569,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 33.225115,
-        "longitude": -87.544176,
         "name": "Tuscaloosa",
-        "namealt": null,
         "national": null,
         "pop_max": 121373,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8113,13 +6587,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 34.014550,
-        "longitude": -86.006647,
         "name": "Gadsden",
-        "namealt": null,
         "national": null,
         "pop_max": 41709,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8135,13 +6605,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 31.327815,
-        "longitude": -85.843996,
         "name": "Enterprise",
-        "namealt": null,
         "national": null,
         "pop_max": 24205,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8157,13 +6623,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 32.407568,
-        "longitude": -87.021159,
         "name": "Selma",
-        "namealt": null,
         "national": null,
         "pop_max": 20126,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8179,13 +6641,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 33.530006,
-        "longitude": -86.824995,
         "name": "Birmingham",
-        "namealt": null,
         "national": null,
         "pop_max": 1128047,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -8201,13 +6659,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 30.680025,
-        "longitude": -88.049985,
         "name": "Mobile",
-        "namealt": null,
         "national": null,
         "pop_max": 253466,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -8223,13 +6677,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 34.719960,
-        "longitude": -86.609995,
         "name": "Huntsville",
-        "namealt": null,
         "national": null,
         "pop_max": 212733,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -8245,13 +6695,9 @@
       "properties": {
         "adm1name": "Alabama",
         "align": null,
-        "latitude": 32.361602,
-        "longitude": -86.279189,
         "name": "Montgomery",
-        "namealt": null,
         "national": null,
         "pop_max": 198325,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -8267,13 +6713,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 40.947771,
-        "longitude": -90.371084,
         "name": "Galesburg",
-        "namealt": null,
         "national": null,
         "pop_max": 32094,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8289,13 +6731,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 41.529983,
-        "longitude": -88.106674,
         "name": "Joliet",
-        "namealt": null,
         "national": null,
         "pop_max": 578460,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8311,13 +6749,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 37.305822,
-        "longitude": -89.518087,
         "name": "Cape Girardeau",
-        "namealt": null,
         "national": null,
         "pop_max": 40427,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8333,13 +6767,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 42.269705,
-        "longitude": -89.069690,
         "name": "Rockford",
-        "namealt": null,
         "national": null,
         "pop_max": 255978,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -8355,13 +6785,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 42.048349,
-        "longitude": -87.699955,
         "name": "Evanston",
-        "namealt": null,
         "national": null,
         "pop_max": 350000,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8377,13 +6803,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 41.493396,
-        "longitude": -90.534614,
         "name": "Rock Island",
-        "namealt": null,
         "national": null,
         "pop_max": 165728,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8399,13 +6821,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 42.039461,
-        "longitude": -88.289919,
         "name": "Elgin",
-        "namealt": null,
         "national": null,
         "pop_max": 389514,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8421,13 +6839,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 39.840706,
-        "longitude": -88.954736,
         "name": "Decatur",
-        "namealt": null,
         "national": null,
         "pop_max": 77868,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8443,13 +6857,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 38.890997,
-        "longitude": -90.184222,
         "name": "Alton",
-        "namealt": null,
         "national": null,
         "pop_max": 84276,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8465,13 +6875,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 39.935972,
-        "longitude": -91.409728,
         "name": "Quincy",
-        "namealt": null,
         "national": null,
         "pop_max": 47108,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8487,13 +6893,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 40.109992,
-        "longitude": -88.204187,
         "name": "Urbana",
-        "namealt": null,
         "national": null,
         "pop_max": 144074,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8509,13 +6911,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 40.484595,
-        "longitude": -88.993597,
         "name": "Bloomington",
-        "namealt": null,
         "national": null,
         "pop_max": 128979,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8531,13 +6929,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 41.120370,
-        "longitude": -87.861108,
         "name": "Kankakee",
-        "namealt": null,
         "national": null,
         "pop_max": 69608,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8553,13 +6947,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 42.364041,
-        "longitude": -87.844726,
         "name": "Waukegan",
-        "namealt": null,
         "national": null,
         "pop_max": 200000,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8575,13 +6965,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 41.765395,
-        "longitude": -88.299996,
         "name": "Aurora",
-        "namealt": null,
         "national": null,
         "pop_max": 350000,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8597,13 +6983,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 37.726830,
-        "longitude": -89.220249,
         "name": "Carbondale",
-        "namealt": null,
         "national": null,
         "pop_max": 32444,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8619,13 +7001,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 38.525154,
-        "longitude": -90.000228,
         "name": "Belleville",
-        "namealt": null,
         "national": null,
         "pop_max": 143900,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8641,13 +7019,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": "bottom",
-        "latitude": 39.820010,
-        "longitude": -89.650017,
         "name": "Springfield",
-        "namealt": null,
         "national": null,
         "pop_max": 134715,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -8663,13 +7037,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": null,
-        "latitude": 40.699982,
-        "longitude": -89.670041,
         "name": "Peoria",
-        "namealt": null,
         "national": null,
         "pop_max": 172308,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -8685,13 +7055,9 @@
       "properties": {
         "adm1name": "Illinois",
         "align": "right",
-        "latitude": 41.829991,
-        "longitude": -87.750055,
         "name": "Chicago",
-        "namealt": null,
         "national": 1,
         "pop_max": 8990000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -8707,13 +7073,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 39.828898,
-        "longitude": -84.890281,
         "name": "Richmond",
-        "namealt": null,
         "national": null,
         "pop_max": 44400,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8729,13 +7091,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 39.466647,
-        "longitude": -87.413874,
         "name": "Terre Haute",
-        "namealt": null,
         "national": null,
         "pop_max": 73236,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8751,13 +7109,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 40.417209,
-        "longitude": -86.878248,
         "name": "Lafayette",
-        "namealt": null,
         "national": null,
         "pop_max": 133977,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8773,13 +7127,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 40.558337,
-        "longitude": -85.659175,
         "name": "Marion",
-        "namealt": null,
         "national": null,
         "pop_max": 38297,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8795,13 +7145,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 41.683307,
-        "longitude": -86.250017,
         "name": "South Bend",
-        "namealt": null,
         "national": null,
         "pop_max": 239822,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8816,15 +7162,11 @@
       },
       "properties": {
         "adm1name": "Indiana",
-        "align": "left",
-        "latitude": 38.310877,
-        "longitude": -85.821284,
+        "align": "right",
         "name": "New Albany",
-        "namealt": null,
         "national": null,
         "pop_max": 120625,
-        "scalerank": 8,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -8839,13 +7181,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 41.682945,
-        "longitude": -85.968794,
         "name": "Elkhart",
-        "namealt": null,
         "national": null,
         "pop_max": 149190,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -8861,13 +7199,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 39.165657,
-        "longitude": -86.526409,
         "name": "Bloomington",
-        "namealt": null,
         "national": null,
         "pop_max": 100310,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8883,13 +7217,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 40.193760,
-        "longitude": -85.386375,
         "name": "Muncie",
-        "namealt": null,
         "national": null,
         "pop_max": 85449,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8905,13 +7235,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 40.486765,
-        "longitude": -86.133642,
         "name": "Kokomo",
-        "namealt": null,
         "national": null,
         "pop_max": 61121,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -8927,13 +7253,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 41.580393,
-        "longitude": -87.330003,
         "name": "Gary",
-        "namealt": null,
         "national": null,
         "pop_max": 591180,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -8949,13 +7271,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 41.080398,
-        "longitude": -85.129982,
         "name": "Fort Wayne",
-        "namealt": null,
         "national": null,
         "pop_max": 299871,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -8971,13 +7289,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": null,
-        "latitude": 37.974696,
-        "longitude": -87.555829,
         "name": "Evansville",
-        "namealt": null,
         "national": null,
         "pop_max": 174102,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -8993,13 +7307,9 @@
       "properties": {
         "adm1name": "Indiana",
         "align": "bottom",
-        "latitude": 39.749988,
-        "longitude": -86.170048,
         "name": "Indianapolis",
-        "namealt": null,
         "national": null,
         "pop_max": 1436000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -9015,13 +7325,9 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 41.656125,
-        "longitude": -70.944698,
         "name": "New Bedford",
-        "namealt": null,
         "national": null,
         "pop_max": 136082,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9037,13 +7343,9 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 42.120025,
-        "longitude": -72.579999,
         "name": "Springfield",
-        "namealt": null,
         "national": null,
         "pop_max": 421780,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -9059,14 +7361,10 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 42.522499,
-        "longitude": -70.883092,
         "name": "Salem",
-        "namealt": null,
         "national": null,
         "pop_max": 335509,
-        "scalerank": 8,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -9081,36 +7379,10 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 42.448196,
-        "longitude": -73.259828,
         "name": "Pittsfield",
-        "namealt": null,
         "national": null,
         "pop_max": 46230,
-        "scalerank": 8,
         "visible": 0
-      },
-      "type": "Feature"
-    },
-    {
-      "geometry": {
-        "coordinates": [
-          -71.316691123119199,
-          42.633688373884922
-        ],
-        "type": "Point"
-      },
-      "properties": {
-        "adm1name": "Massachusetts",
-        "align": null,
-        "latitude": 42.633688,
-        "longitude": -71.316691,
-        "name": "Lowell",
-        "namealt": null,
-        "national": null,
-        "pop_max": 723629,
-        "scalerank": 7,
-        "visible": 1
       },
       "type": "Feature"
     },
@@ -9125,13 +7397,9 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 42.270429,
-        "longitude": -71.800021,
         "name": "Worcester",
-        "namealt": null,
         "national": null,
         "pop_max": 287365,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9147,13 +7415,9 @@
       "properties": {
         "adm1name": "Massachusetts",
         "align": null,
-        "latitude": 42.329960,
-        "longitude": -71.070014,
         "name": "Boston",
-        "namealt": null,
         "national": 1,
         "pop_max": 4467000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -9169,13 +7433,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.873901,
-        "longitude": -122.271152,
         "name": "Berkeley",
-        "namealt": null,
         "national": null,
         "pop_max": 496356,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9191,13 +7451,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 32.671945,
-        "longitude": -117.098005,
         "name": "National City",
-        "namealt": null,
         "national": null,
         "pop_max": 150000,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9213,13 +7469,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 39.307767,
-        "longitude": -123.799431,
         "name": "Mendocino",
-        "namealt": null,
         "national": null,
         "pop_max": 548,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9235,13 +7487,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 35.626597,
-        "longitude": -120.689982,
         "name": "Paso Robles",
-        "namealt": null,
         "national": null,
         "pop_max": 27157,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9257,13 +7505,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.941945,
-        "longitude": -117.398039,
         "name": "Riverside",
-        "namealt": null,
         "national": null,
         "pop_max": 297554,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9279,13 +7523,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 35.761937,
-        "longitude": -119.243068,
         "name": "Delano",
-        "namealt": null,
         "national": null,
         "pop_max": 44757,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9301,13 +7541,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.556918,
-        "longitude": -122.313062,
         "name": "San Mateo",
-        "namealt": null,
         "national": null,
         "pop_max": 626406,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9323,13 +7559,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 38.111949,
-        "longitude": -122.258052,
         "name": "Vallejo",
-        "namealt": null,
         "national": null,
         "pop_max": 146289,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -9345,13 +7577,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 40.885190,
-        "longitude": -124.088225,
         "name": "Arcata",
-        "namealt": null,
         "national": null,
         "pop_max": 20905,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9367,13 +7595,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.958134,
-        "longitude": -121.289739,
         "name": "Stockton",
-        "namealt": null,
         "national": null,
         "pop_max": 685306,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9389,13 +7613,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.899018,
-        "longitude": -117.021886,
         "name": "Barstow",
-        "namealt": null,
         "national": null,
         "pop_max": 21119,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9411,13 +7631,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.536508,
-        "longitude": -117.290319,
         "name": "Victorville",
-        "namealt": null,
         "national": null,
         "pop_max": 83496,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9433,13 +7649,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.160381,
-        "longitude": -118.138872,
         "name": "Pasadena",
-        "namealt": null,
         "national": null,
         "pop_max": 144618,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9455,13 +7667,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 36.325030,
-        "longitude": -119.316009,
         "name": "Visalia",
-        "namealt": null,
         "national": null,
         "pop_max": 121968,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9477,13 +7685,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 32.792377,
-        "longitude": -115.558048,
         "name": "El Centro",
-        "namealt": null,
         "national": null,
         "pop_max": 45000,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9499,13 +7703,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 35.283181,
-        "longitude": -120.658589,
         "name": "San Luis Obispo",
-        "namealt": null,
         "national": null,
         "pop_max": 65386,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9521,13 +7721,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.302618,
-        "longitude": -120.481933,
         "name": "Merced",
-        "namealt": null,
         "national": null,
         "pop_max": 96091,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9543,13 +7739,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 39.141033,
-        "longitude": -121.615766,
         "name": "Yuba City",
-        "namealt": null,
         "national": null,
         "pop_max": 116217,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9565,13 +7757,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 40.587043,
-        "longitude": -122.390576,
         "name": "Redding",
-        "namealt": null,
         "national": null,
         "pop_max": 96058,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9587,13 +7775,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 38.450404,
-        "longitude": -122.699989,
         "name": "Santa Rosa",
-        "namealt": null,
         "national": null,
         "pop_max": 231792,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9609,13 +7793,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.220464,
-        "longitude": -117.334967,
         "name": "Oceanside",
-        "namealt": null,
         "national": null,
         "pop_max": 609854,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9631,13 +7811,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.655413,
-        "longitude": -120.989990,
         "name": "Modesto",
-        "namealt": null,
         "national": null,
         "pop_max": 323386,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9653,13 +7829,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.680411,
-        "longitude": -117.829950,
         "name": "Irvine",
-        "namealt": null,
         "national": null,
         "pop_max": 3010232,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9675,13 +7847,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 39.154237,
-        "longitude": -123.210862,
         "name": "Ukiah",
-        "namealt": null,
         "national": null,
         "pop_max": 27828,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9697,13 +7865,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.848427,
-        "longitude": -114.613351,
         "name": "Needles",
-        "namealt": null,
         "national": null,
         "pop_max": 6974,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9719,13 +7883,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.363958,
-        "longitude": -118.394076,
         "name": "Bishop",
-        "namealt": null,
         "national": null,
         "pop_max": 4827,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9741,13 +7901,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.777356,
-        "longitude": -116.533053,
         "name": "Palm Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 390115,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9763,13 +7919,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.940127,
-        "longitude": -120.436639,
         "name": "Santa Maria",
-        "namealt": null,
         "national": null,
         "pop_max": 110705,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9785,13 +7937,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 36.207026,
-        "longitude": -119.344121,
         "name": "Tulare",
-        "namealt": null,
         "national": null,
         "pop_max": 55908,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9807,13 +7955,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 41.310358,
-        "longitude": -122.309393,
         "name": "Mt. Shasta",
-        "namealt": null,
         "national": null,
         "pop_max": 3855,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9829,13 +7973,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 41.756455,
-        "longitude": -124.200492,
         "name": "Crescent City",
-        "namealt": null,
         "national": null,
         "pop_max": 11534,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -9851,13 +7991,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.786967,
-        "longitude": -118.158044,
         "name": "Long Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 2036134,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9873,13 +8009,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 35.369972,
-        "longitude": -119.019981,
         "name": "Bakersfield",
-        "namealt": null,
         "national": null,
         "pop_max": 443129,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9895,13 +8027,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.768921,
-        "longitude": -122.221103,
         "name": "Oakland",
-        "namealt": null,
         "national": null,
         "pop_max": 1510271,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9917,13 +8045,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.698049,
-        "longitude": -118.135823,
         "name": "Lancaster",
-        "namealt": null,
         "national": null,
         "pop_max": 225799,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9939,13 +8063,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 39.728620,
-        "longitude": -121.836398,
         "name": "Chico",
-        "namealt": null,
         "national": null,
         "pop_max": 95888,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9961,13 +8081,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 36.600258,
-        "longitude": -121.893578,
         "name": "Monterey",
-        "namealt": null,
         "national": null,
         "pop_max": 124288,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -9983,13 +8099,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 36.682217,
-        "longitude": -121.641656,
         "name": "Salinas",
-        "namealt": null,
         "national": null,
         "pop_max": 156784,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -10005,13 +8117,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.120384,
-        "longitude": -117.300034,
         "name": "San Bernardino",
-        "namealt": "Riverside-San Bernardino",
         "national": null,
         "pop_max": 1745000,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -10027,13 +8135,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 34.434990,
-        "longitude": -119.719990,
         "name": "Santa Barbara",
-        "namealt": null,
         "national": null,
         "pop_max": 181632,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -10049,13 +8153,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 36.747717,
-        "longitude": -119.772984,
         "name": "Fresno",
-        "namealt": null,
         "national": null,
         "pop_max": 616353,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -10071,13 +8171,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 40.802224,
-        "longitude": -124.147497,
         "name": "Eureka",
-        "namealt": null,
         "national": null,
         "pop_max": 42398,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -10093,13 +8189,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.299983,
-        "longitude": -121.849989,
         "name": "San Jose",
-        "namealt": null,
         "national": null,
         "pop_max": 1668000,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -10115,13 +8207,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 38.575021,
-        "longitude": -121.470038,
         "name": "Sacramento",
-        "namealt": null,
         "national": null,
         "pop_max": 1604000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -10137,13 +8225,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 32.820024,
-        "longitude": -117.179990,
         "name": "San Diego",
-        "namealt": null,
         "national": 1,
         "pop_max": 2916000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -10159,13 +8243,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 37.740008,
-        "longitude": -122.459978,
         "name": "San Francisco",
-        "namealt": "San Francisco-Oakland",
         "national": 1,
         "pop_max": 3450000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -10181,13 +8261,9 @@
       "properties": {
         "adm1name": "California",
         "align": null,
-        "latitude": 33.989978,
-        "longitude": -118.179981,
         "name": "Los Angeles",
-        "namealt": "Los Angeles-Long Beach-Santa Ana",
         "national": 1,
         "pop_max": 12500000,
-        "scalerank": 0,
         "visible": 1
       },
       "type": "Feature"
@@ -10203,13 +8279,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.949429,
-        "longitude": -81.932271,
         "name": "Spartanburg",
-        "namealt": null,
         "national": null,
         "pop_max": 124126,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10225,13 +8297,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 33.496804,
-        "longitude": -80.862233,
         "name": "Orangeburg",
-        "namealt": null,
         "national": null,
         "pop_max": 35472,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10247,13 +8315,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.195676,
-        "longitude": -79.762791,
         "name": "Florence",
-        "namealt": null,
         "national": null,
         "pop_max": 57438,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10269,13 +8333,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.852923,
-        "longitude": -82.394155,
         "name": "Greenville",
-        "namealt": null,
         "national": null,
         "pop_max": 350954,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -10291,13 +8351,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 33.920654,
-        "longitude": -80.341722,
         "name": "Sumter",
-        "namealt": null,
         "national": null,
         "pop_max": 50868,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10313,13 +8369,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.503745,
-        "longitude": -82.650263,
         "name": "Anderson",
-        "namealt": null,
         "national": null,
         "pop_max": 61558,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10335,13 +8387,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 33.549463,
-        "longitude": -81.720604,
         "name": "Aiken",
-        "namealt": null,
         "national": null,
         "pop_max": 46196,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10357,13 +8405,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 32.432166,
-        "longitude": -80.689504,
         "name": "Beaufort",
-        "namealt": null,
         "national": null,
         "pop_max": 31626,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10379,13 +8423,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.940385,
-        "longitude": -81.030000,
         "name": "Rock Hill",
-        "namealt": null,
         "national": null,
         "pop_max": 94564,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10401,13 +8441,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 33.688911,
-        "longitude": -78.886978,
         "name": "Myrtle Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 49357,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -10423,13 +8459,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 32.792377,
-        "longitude": -79.992105,
         "name": "Charleston",
-        "namealt": null,
         "national": null,
         "pop_max": 411940,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -10445,13 +8477,9 @@
       "properties": {
         "adm1name": "South Carolina",
         "align": null,
-        "latitude": 34.039975,
-        "longitude": -80.899982,
         "name": "Columbia",
-        "namealt": null,
         "national": null,
         "pop_max": 398093,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -10467,13 +8495,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 39.546590,
-        "longitude": -107.324700,
         "name": "Glenwood Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 14004,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10489,13 +8513,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 39.695857,
-        "longitude": -104.808497,
         "name": "Aurora",
-        "namealt": null,
         "national": null,
         "pop_max": 587540,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10511,13 +8531,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 40.419198,
-        "longitude": -104.739974,
         "name": "Greeley",
-        "namealt": null,
         "national": null,
         "pop_max": 125410,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10533,13 +8549,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 40.560688,
-        "longitude": -105.058869,
         "name": "Fort Collins",
-        "namealt": null,
         "national": null,
         "pop_max": 228385,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -10555,13 +8567,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 38.280388,
-        "longitude": -104.630007,
         "name": "Pueblo",
-        "namealt": null,
         "national": null,
         "pop_max": 112195,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10577,13 +8585,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 38.086498,
-        "longitude": -102.619406,
         "name": "Lamar",
-        "namealt": null,
         "national": null,
         "pop_max": 8620,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10599,13 +8603,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 37.171334,
-        "longitude": -104.506397,
         "name": "Trinidad",
-        "namealt": null,
         "national": null,
         "pop_max": 9156,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10621,13 +8621,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 38.544765,
-        "longitude": -106.928290,
         "name": "Gunnison",
-        "namealt": null,
         "national": null,
         "pop_max": 7324,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10643,13 +8639,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 37.275643,
-        "longitude": -107.879989,
         "name": "Durango",
-        "namealt": null,
         "national": null,
         "pop_max": 23233,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10665,13 +8657,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 38.477275,
-        "longitude": -107.865520,
         "name": "Montrose",
-        "namealt": null,
         "national": null,
         "pop_max": 21789,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10687,13 +8675,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 40.517280,
-        "longitude": -107.550397,
         "name": "Craig",
-        "namealt": null,
         "national": null,
         "pop_max": 9391,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10709,13 +8693,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 40.038446,
-        "longitude": -105.246093,
         "name": "Boulder",
-        "namealt": null,
         "national": null,
         "pop_max": 122274,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10731,13 +8711,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 39.093853,
-        "longitude": -108.550000,
         "name": "Grand Junction",
-        "namealt": null,
         "national": null,
         "pop_max": 104214,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -10753,13 +8729,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": "bottom",
-        "latitude": 38.862962,
-        "longitude": -104.791986,
         "name": "Colorado Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 493654,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -10775,13 +8747,9 @@
       "properties": {
         "adm1name": "Colorado",
         "align": null,
-        "latitude": 39.739188,
-        "longitude": -104.984016,
         "name": "Denver",
-        "namealt": "Denver-Aurora",
         "national": 1,
         "pop_max": 2313000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -10797,13 +8765,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.082963,
-        "longitude": -73.785016,
         "name": "Saratoga Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 55793,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10819,13 +8783,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 41.700231,
-        "longitude": -73.921416,
         "name": "Poughkeepsie",
-        "namealt": null,
         "national": null,
         "pop_max": 170996,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10841,13 +8801,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 44.694984,
-        "longitude": -73.457982,
         "name": "Plattsburg",
-        "namealt": null,
         "national": null,
         "pop_max": 29238,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -10863,13 +8819,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.814582,
-        "longitude": -73.939968,
         "name": "Schenectady",
-        "namealt": null,
         "national": null,
         "pop_max": 149255,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10885,13 +8837,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.099018,
-        "longitude": -75.918322,
         "name": "Binghamton",
-        "namealt": null,
         "national": null,
         "pop_max": 139895,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10907,13 +8855,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.101179,
-        "longitude": -75.233067,
         "name": "Utica",
-        "namealt": null,
         "national": null,
         "pop_max": 105150,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10929,13 +8873,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.975157,
-        "longitude": -75.911062,
         "name": "Watertown",
-        "namealt": null,
         "national": null,
         "pop_max": 33821,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10951,13 +8891,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.094823,
-        "longitude": -79.036943,
         "name": "Niagara Falls",
-        "namealt": null,
         "national": null,
         "pop_max": 153134,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10973,13 +8909,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.097365,
-        "longitude": -79.235536,
         "name": "Jamestown",
-        "namealt": null,
         "national": null,
         "pop_max": 45756,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -10995,13 +8927,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.090130,
-        "longitude": -76.808036,
         "name": "Elmira",
-        "namealt": null,
         "national": null,
         "pop_max": 62376,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11017,13 +8945,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.670017,
-        "longitude": -73.819949,
         "name": "Albany",
-        "namealt": null,
         "national": null,
         "pop_max": 870716,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -11039,13 +8963,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.440574,
-        "longitude": -76.496943,
         "name": "Ithaca",
-        "namealt": null,
         "national": null,
         "pop_max": 59930,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -11061,13 +8981,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.170426,
-        "longitude": -77.619950,
         "name": "Rochester",
-        "namealt": null,
         "national": null,
         "pop_max": 755000,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -11083,13 +8999,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 43.049994,
-        "longitude": -76.150014,
         "name": "Syracuse",
-        "namealt": null,
         "national": null,
         "pop_max": 662577,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -11105,13 +9017,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 42.879978,
-        "longitude": -78.880002,
         "name": "Buffalo",
-        "namealt": null,
         "national": null,
         "pop_max": 1016000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -11127,13 +9035,9 @@
       "properties": {
         "adm1name": "New York",
         "align": null,
-        "latitude": 40.749979,
-        "longitude": -73.980017,
         "name": "New York",
-        "namealt": "New York-Newark",
         "national": 1,
         "pop_max": 19040000,
-        "scalerank": 0,
         "visible": 1
       },
       "type": "Feature"
@@ -11149,13 +9053,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.116640,
-        "longitude": -86.454191,
         "name": "Benton Harbor",
-        "namealt": null,
         "national": null,
         "pop_max": 58382,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11171,13 +9071,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.321098,
-        "longitude": -85.179747,
         "name": "Battle Creek",
-        "namealt": null,
         "national": null,
         "pop_max": 70820,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11193,13 +9089,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 43.594457,
-        "longitude": -83.888895,
         "name": "Bay City",
-        "namealt": null,
         "national": null,
         "pop_max": 68549,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11215,13 +9107,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 45.061602,
-        "longitude": -83.432696,
         "name": "Alpena",
-        "namealt": null,
         "national": null,
         "pop_max": 18330,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11237,13 +9125,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 45.822460,
-        "longitude": -88.064093,
         "name": "Iron Mountain",
-        "namealt": null,
         "national": null,
         "pop_max": 16183,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11259,13 +9143,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 46.455806,
-        "longitude": -90.159391,
         "name": "Ironwood",
-        "namealt": null,
         "national": null,
         "pop_max": 7064,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11281,13 +9161,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.300375,
-        "longitude": -83.719991,
         "name": "Ann Arbor",
-        "namealt": null,
         "national": null,
         "pop_max": 265976,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11303,13 +9179,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.292159,
-        "longitude": -85.587190,
         "name": "Kalamazoo",
-        "namealt": null,
         "national": null,
         "pop_max": 183381,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11325,13 +9197,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 43.234582,
-        "longitude": -86.248364,
         "name": "Muskegon",
-        "namealt": null,
         "national": null,
         "pop_max": 101177,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11347,13 +9215,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 43.012864,
-        "longitude": -83.687538,
         "name": "Flint",
-        "namealt": null,
         "national": null,
         "pop_max": 295212,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -11369,13 +9233,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.963720,
-        "longitude": -85.669949,
         "name": "Grand Rapids",
-        "namealt": null,
         "national": null,
         "pop_max": 535829,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -11391,13 +9251,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.651853,
-        "longitude": -83.290224,
         "name": "Pontiac",
-        "namealt": null,
         "national": null,
         "pop_max": 67994,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11413,13 +9269,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 44.251212,
-        "longitude": -85.413608,
         "name": "Cadillac",
-        "namealt": null,
         "national": null,
         "pop_max": 14097,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11435,13 +9287,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 44.768442,
-        "longitude": -85.622175,
         "name": "Traverse City",
-        "namealt": null,
         "national": null,
         "pop_max": 43189,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11457,13 +9305,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 45.373754,
-        "longitude": -84.955187,
         "name": "Petoskey",
-        "namealt": null,
         "national": null,
         "pop_max": 12667,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11479,13 +9323,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 45.745695,
-        "longitude": -87.064360,
         "name": "Escanaba",
-        "namealt": null,
         "national": null,
         "pop_max": 17318,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11501,13 +9341,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 46.546731,
-        "longitude": -87.406588,
         "name": "Marquette",
-        "namealt": null,
         "national": null,
         "pop_max": 26591,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11523,13 +9359,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 47.127290,
-        "longitude": -88.580805,
         "name": "Hancock",
-        "namealt": null,
         "national": null,
         "pop_max": 16355,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11545,14 +9377,10 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 42.733527,
-        "longitude": -84.546736,
         "name": "Lansing",
-        "namealt": null,
         "national": null,
         "pop_max": 279952,
-        "scalerank": 6,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -11567,13 +9395,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 43.419480,
-        "longitude": -83.950830,
         "name": "Saginaw",
-        "namealt": null,
         "national": null,
         "pop_max": 121379,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -11589,13 +9413,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": null,
-        "latitude": 46.495261,
-        "longitude": -84.345276,
         "name": "Sault Ste. Marie",
-        "namealt": null,
         "national": null,
         "pop_max": 83805,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -11611,13 +9431,9 @@
       "properties": {
         "adm1name": "Michigan",
         "align": "bottom",
-        "latitude": 42.329960,
-        "longitude": -83.080056,
         "name": "Detroit",
-        "namealt": null,
         "national": 1,
         "pop_max": 4101000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -11633,13 +9449,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 39.091114,
-        "longitude": -94.415281,
         "name": "Independence",
-        "namealt": null,
         "national": null,
         "pop_max": 148102,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11655,13 +9467,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 40.193682,
-        "longitude": -92.582809,
         "name": "Kirksville",
-        "namealt": null,
         "national": null,
         "pop_max": 19193,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11677,13 +9485,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 38.784285,
-        "longitude": -90.506166,
         "name": "St. Charles",
-        "namealt": null,
         "national": null,
         "pop_max": 360485,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11699,13 +9503,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 36.760197,
-        "longitude": -90.402684,
         "name": "Poplar Bluff",
-        "namealt": null,
         "national": null,
         "pop_max": 20662,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11721,13 +9521,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 37.084596,
-        "longitude": -94.513079,
         "name": "Joplin",
-        "namealt": null,
         "national": null,
         "pop_max": 73763,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11743,13 +9539,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 38.952078,
-        "longitude": -92.333910,
         "name": "Columbia",
-        "namealt": null,
         "national": null,
         "pop_max": 398093,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -11765,13 +9557,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 39.769031,
-        "longitude": -94.846392,
         "name": "St. Joseph",
-        "namealt": null,
         "national": null,
         "pop_max": 78012,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11787,14 +9575,10 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 38.576623,
-        "longitude": -92.173325,
         "name": "Jefferson City",
-        "namealt": null,
         "national": null,
         "pop_max": 55139,
-        "scalerank": 6,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -11809,13 +9593,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 37.180016,
-        "longitude": -93.319999,
         "name": "Springfield",
-        "namealt": null,
         "national": null,
         "pop_max": 210939,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -11831,13 +9611,9 @@
       "properties": {
         "adm1name": "Missouri",
         "align": null,
-        "latitude": 39.107089,
-        "longitude": -94.604094,
         "name": "Kansas City",
-        "namealt": null,
         "national": null,
         "pop_max": 1469000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -11852,14 +9628,9 @@
       },
       "properties": {
         "adm1name": "Missouri",
-        "align": "right",
-        "latitude": 38.635018,
-        "longitude": -90.239981,
         "name": "St. Louis",
-        "namealt": null,
         "national": null,
         "pop_max": 2199000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -11875,13 +9646,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.211377,
-        "longitude": -119.136098,
         "name": "Kennewick",
-        "namealt": null,
         "national": null,
         "pop_max": 102504,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11897,13 +9664,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.716411,
-        "longitude": -122.952971,
         "name": "Centralia",
-        "namealt": null,
         "national": null,
         "pop_max": 18880,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -11919,13 +9682,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.291811,
-        "longitude": -119.291101,
         "name": "Richland",
-        "namealt": null,
         "national": null,
         "pop_max": 44869,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11941,13 +9700,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 48.760136,
-        "longitude": -122.486927,
         "name": "Bellingham",
-        "namealt": null,
         "national": null,
         "pop_max": 99662,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11963,13 +9718,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.138720,
-        "longitude": -122.936951,
         "name": "Longview",
-        "namealt": null,
         "national": null,
         "pop_max": 66231,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -11985,13 +9736,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.065159,
-        "longitude": -118.341883,
         "name": "Walla Walla",
-        "namealt": null,
         "national": null,
         "pop_max": 45150,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12007,13 +9754,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.974896,
-        "longitude": -123.814391,
         "name": "Aberdeen",
-        "namealt": null,
         "national": null,
         "pop_max": 32745,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12029,13 +9772,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.573596,
-        "longitude": -122.642018,
         "name": "Bremerton",
-        "namealt": null,
         "national": null,
         "pop_max": 126820,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12051,13 +9790,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.960417,
-        "longitude": -122.199968,
         "name": "Everett",
-        "namealt": null,
         "national": null,
         "pop_max": 486903,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12073,13 +9808,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.211316,
-        "longitude": -122.515013,
         "name": "Tacoma",
-        "namealt": null,
         "national": null,
         "pop_max": 719868,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -12095,13 +9826,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 46.602232,
-        "longitude": -120.504696,
         "name": "Yakima",
-        "namealt": null,
         "national": null,
         "pop_max": 99287,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -12117,13 +9844,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.423629,
-        "longitude": -120.309024,
         "name": "Wenatchee",
-        "namealt": null,
         "national": null,
         "pop_max": 62625,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -12139,14 +9862,10 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.038045,
-        "longitude": -122.899434,
         "name": "Olympia",
-        "namealt": null,
         "national": null,
         "pop_max": 156984,
-        "scalerank": 4,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -12161,13 +9880,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 47.669996,
-        "longitude": -117.419949,
         "name": "Spokane",
-        "namealt": null,
         "national": null,
         "pop_max": 347705,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -12183,13 +9898,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": null,
-        "latitude": 45.630301,
-        "longitude": -122.639993,
         "name": "Vancouver",
-        "namealt": null,
         "national": null,
         "pop_max": 525802,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -12205,13 +9916,9 @@
       "properties": {
         "adm1name": "Washington",
         "align": "right",
-        "latitude": 47.570002,
-        "longitude": -122.339985,
         "name": "Seattle",
-        "namealt": null,
         "national": 1,
         "pop_max": 3074000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -12227,13 +9934,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 55.339709,
-        "longitude": -160.497191,
         "name": "Sand Point",
-        "namealt": null,
         "national": null,
         "pop_max": 667,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12249,13 +9952,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 55.213980,
-        "longitude": -132.800638,
         "name": "Hydaburg",
-        "namealt": null,
         "national": null,
         "pop_max": 382,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12271,13 +9970,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.388647,
-        "longitude": -166.189937,
         "name": "Mekoryuk",
-        "namealt": null,
         "national": null,
         "pop_max": 99,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12293,13 +9988,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 70.469379,
-        "longitude": -157.395778,
         "name": "Atqasuk",
-        "namealt": null,
         "national": null,
         "pop_max": 201,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12315,13 +10006,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 56.949094,
-        "longitude": -158.626892,
         "name": "Port Heiden",
-        "namealt": null,
         "national": null,
         "pop_max": 102,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12337,13 +10024,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 55.918614,
-        "longitude": -159.151149,
         "name": "Perryville",
-        "namealt": null,
         "national": null,
         "pop_max": 113,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12359,13 +10042,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.056560,
-        "longitude": -158.480312,
         "name": "Dillingham",
-        "namealt": null,
         "national": null,
         "pop_max": 2488,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12381,13 +10060,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.120993,
-        "longitude": -161.587130,
         "name": "Goodnews Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 230,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12403,13 +10078,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.004143,
-        "longitude": -159.940481,
         "name": "Nyac",
-        "namealt": null,
         "national": null,
         "pop_max": 100,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12425,13 +10096,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.585487,
-        "longitude": -165.255789,
         "name": "Tununak",
-        "namealt": null,
         "national": null,
         "pop_max": 352,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12447,13 +10114,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.085524,
-        "longitude": -163.729009,
         "name": "Mountain Village",
-        "namealt": null,
         "national": null,
         "pop_max": 755,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12469,13 +10132,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.776981,
-        "longitude": -164.522992,
         "name": "Emmonak",
-        "namealt": null,
         "national": null,
         "pop_max": 100,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12491,13 +10150,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.327196,
-        "longitude": -158.721899,
         "name": "Kaltag",
-        "namealt": null,
         "national": null,
         "pop_max": 190,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12513,13 +10168,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 65.263599,
-        "longitude": -166.360786,
         "name": "Teller",
-        "namealt": null,
         "national": null,
         "pop_max": 83,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12535,13 +10186,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.880289,
-        "longitude": -157.700850,
         "name": "Koyukuk",
-        "namealt": null,
         "national": null,
         "pop_max": 101,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12557,13 +10204,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.907246,
-        "longitude": -156.880977,
         "name": "Kobuk",
-        "namealt": null,
         "national": null,
         "pop_max": 151,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12579,13 +10222,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.603879,
-        "longitude": -160.009391,
         "name": "Selawik",
-        "namealt": null,
         "national": null,
         "pop_max": 832,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12601,13 +10240,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.323779,
-        "longitude": -150.109427,
         "name": "Talkeetna",
-        "namealt": null,
         "national": null,
         "pop_max": 1078,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12623,13 +10258,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.784157,
-        "longitude": -148.677680,
         "name": "Whittier",
-        "namealt": null,
         "national": null,
         "pop_max": 177,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12645,13 +10276,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.079685,
-        "longitude": -150.072762,
         "name": "Montana",
-        "namealt": null,
         "national": null,
         "pop_max": 10,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12667,13 +10294,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.882831,
-        "longitude": -152.312187,
         "name": "Lake Minchumina",
-        "namealt": null,
         "national": null,
         "pop_max": 32,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12689,13 +10312,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.391594,
-        "longitude": -148.950790,
         "name": "Cantwell",
-        "namealt": null,
         "national": null,
         "pop_max": 222,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12711,13 +10330,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.271353,
-        "longitude": -145.382196,
         "name": "Gulkana",
-        "namealt": null,
         "national": null,
         "pop_max": 119,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12733,13 +10348,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.787995,
-        "longitude": -141.199997,
         "name": "Eagle",
-        "namealt": null,
         "national": null,
         "pop_max": 104,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12755,13 +10366,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.563797,
-        "longitude": -149.093003,
         "name": "Nenana",
-        "namealt": null,
         "national": null,
         "pop_max": 75,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12777,13 +10384,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.152530,
-        "longitude": -145.842194,
         "name": "Big Delta",
-        "namealt": null,
         "national": null,
         "pop_max": 591,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12799,13 +10402,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.565483,
-        "longitude": -152.645500,
         "name": "Allakaket",
-        "namealt": null,
         "national": null,
         "pop_max": 97,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12821,13 +10420,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 65.171873,
-        "longitude": -152.078790,
         "name": "Tanana",
-        "namealt": null,
         "national": null,
         "pop_max": 308,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -12843,13 +10438,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 56.471268,
-        "longitude": -132.371595,
         "name": "Wrangell",
-        "namealt": null,
         "national": null,
         "pop_max": 2070,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12865,13 +10456,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.256975,
-        "longitude": -166.071889,
         "name": "Shishmaref",
-        "namealt": null,
         "national": null,
         "pop_max": 254,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12887,13 +10474,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 58.115405,
-        "longitude": -135.438617,
         "name": "Hoonah",
-        "namealt": null,
         "national": null,
         "pop_max": 361,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12909,13 +10492,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 52.196490,
-        "longitude": -174.200489,
         "name": "Atka",
-        "namealt": null,
         "national": null,
         "pop_max": 61,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12931,13 +10510,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 52.938434,
-        "longitude": -168.867688,
         "name": "Nikolski",
-        "namealt": null,
         "national": null,
         "pop_max": 18,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12953,13 +10528,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 57.572286,
-        "longitude": -154.455027,
         "name": "Karluk",
-        "namealt": null,
         "national": null,
         "pop_max": 96,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12975,13 +10546,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 54.851211,
-        "longitude": -163.415023,
         "name": "False Pass",
-        "namealt": null,
         "national": null,
         "pop_max": 35,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -12997,13 +10564,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 67.731492,
-        "longitude": -164.485903,
         "name": "Kivalina",
-        "namealt": null,
         "national": null,
         "pop_max": 374,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13019,13 +10582,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.720346,
-        "longitude": -154.897197,
         "name": "Newhalen",
-        "namealt": null,
         "national": null,
         "pop_max": 160,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13041,13 +10600,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 57.564560,
-        "longitude": -157.569127,
         "name": "Pilot Point",
-        "namealt": null,
         "national": null,
         "pop_max": 68,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13063,13 +10618,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 56.295671,
-        "longitude": -158.402228,
         "name": "Chignik",
-        "namealt": null,
         "national": null,
         "pop_max": 118,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13085,13 +10636,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 58.688703,
-        "longitude": -156.661378,
         "name": "King Salmon",
-        "namealt": null,
         "national": null,
         "pop_max": 292,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13107,13 +10654,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.749233,
-        "longitude": -161.915786,
         "name": "Quinhagak",
-        "namealt": null,
         "national": null,
         "pop_max": 250,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13129,13 +10672,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.578708,
-        "longitude": -159.522186,
         "name": "Aniak",
-        "namealt": null,
         "national": null,
         "pop_max": 501,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13151,13 +10690,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.034588,
-        "longitude": -163.553283,
         "name": "Kotlit",
-        "namealt": null,
         "national": null,
         "pop_max": 1002,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13173,13 +10708,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.873426,
-        "longitude": -160.788052,
         "name": "Unalakleet",
-        "namealt": null,
         "national": null,
         "pop_max": 741,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13195,13 +10726,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.940269,
-        "longitude": -161.157472,
         "name": "Koyuk",
-        "namealt": null,
         "national": null,
         "pop_max": 254,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13217,13 +10744,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 62.956815,
-        "longitude": -155.595785,
         "name": "McGrath",
-        "namealt": null,
         "national": null,
         "pop_max": 138,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13239,13 +10762,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.049184,
-        "longitude": -154.254988,
         "name": "Hughes",
-        "namealt": null,
         "national": null,
         "pop_max": 78,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13261,13 +10780,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 67.086485,
-        "longitude": -157.851409,
         "name": "Ambler",
-        "namealt": null,
         "national": null,
         "pop_max": 258,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13283,13 +10798,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 65.609599,
-        "longitude": -168.087503,
         "name": "Wales",
-        "namealt": null,
         "national": null,
         "pop_max": 99,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13305,13 +10816,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.898693,
-        "longitude": -162.596598,
         "name": "Kotzebue",
-        "namealt": null,
         "national": null,
         "pop_max": 3194,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13327,13 +10834,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.581731,
-        "longitude": -149.439442,
         "name": "Wasilla",
-        "namealt": null,
         "national": null,
         "pop_max": 8521,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13349,13 +10852,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 65.825890,
-        "longitude": -144.060520,
         "name": "Circle",
-        "namealt": null,
         "national": null,
         "pop_max": 100,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13371,13 +10870,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.733098,
-        "longitude": -148.914099,
         "name": "Denali Park",
-        "namealt": null,
         "national": null,
         "pop_max": 1826,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13393,13 +10888,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.547307,
-        "longitude": -139.727218,
         "name": "Yakutat",
-        "namealt": null,
         "national": null,
         "pop_max": 109,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13415,13 +10906,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.642934,
-        "longitude": -151.548280,
         "name": "Homer",
-        "namealt": null,
         "national": null,
         "pop_max": 6560,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13437,13 +10924,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.385703,
-        "longitude": -143.346403,
         "name": "Tanacross",
-        "namealt": null,
         "national": null,
         "pop_max": 136,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13459,13 +10942,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 67.410471,
-        "longitude": -150.107489,
         "name": "Wiseman",
-        "namealt": null,
         "national": null,
         "pop_max": 14,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -13481,13 +10960,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 63.779710,
-        "longitude": -171.731079,
         "name": "Gambell",
-        "namealt": null,
         "national": null,
         "pop_max": 681,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13503,13 +10978,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.599714,
-        "longitude": -149.112692,
         "name": "Palmer",
-        "namealt": null,
         "national": null,
         "pop_max": 13111,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13525,13 +10996,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.126161,
-        "longitude": -149.469983,
         "name": "Seward",
-        "namealt": null,
         "national": null,
         "pop_max": 2900,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13547,13 +11014,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 55.356219,
-        "longitude": -131.663990,
         "name": "Ketchikan",
-        "namealt": null,
         "national": null,
         "pop_max": 9070,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13569,13 +11032,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 53.868584,
-        "longitude": -166.531603,
         "name": "Unalaska",
-        "namealt": null,
         "national": null,
         "pop_max": 3571,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13591,13 +11050,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.070361,
-        "longitude": -160.378323,
         "name": "Togiak",
-        "namealt": null,
         "national": null,
         "pop_max": 236,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13613,13 +11068,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.760996,
-        "longitude": -157.312527,
         "name": "Red Devil",
-        "namealt": null,
         "national": null,
         "pop_max": 25,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13635,13 +11086,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.531088,
-        "longitude": -166.096565,
         "name": "Hooper Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 1079,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13657,13 +11104,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 70.636889,
-        "longitude": -160.038304,
         "name": "Wainwright",
-        "namealt": null,
         "national": null,
         "pop_max": 174,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13679,13 +11122,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.733296,
-        "longitude": -156.926995,
         "name": "Galena",
-        "namealt": null,
         "national": null,
         "pop_max": 500,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13701,13 +11140,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 70.087856,
-        "longitude": -143.602913,
         "name": "Kaktovik",
-        "namealt": null,
         "national": null,
         "pop_max": 101,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13723,13 +11158,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 59.458320,
-        "longitude": -135.313896,
         "name": "Skagway",
-        "namealt": null,
         "national": null,
         "pop_max": 955,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13745,13 +11176,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.542776,
-        "longitude": -145.757496,
         "name": "Cordova",
-        "namealt": null,
         "national": null,
         "pop_max": 2257,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13767,13 +11194,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.554352,
-        "longitude": -151.258013,
         "name": "Kenai",
-        "namealt": null,
         "national": null,
         "pop_max": 7610,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13789,13 +11212,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 66.564682,
-        "longitude": -145.273779,
         "name": "Fort Yukon",
-        "namealt": null,
         "national": null,
         "pop_max": 833,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -13811,13 +11230,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 57.060398,
-        "longitude": -135.327549,
         "name": "Sitka",
-        "namealt": null,
         "national": null,
         "pop_max": 8931,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -13833,13 +11248,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 57.789998,
-        "longitude": -152.406987,
         "name": "Kodiak",
-        "namealt": null,
         "national": null,
         "pop_max": 9461,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13855,13 +11266,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 55.200001,
-        "longitude": -162.715092,
         "name": "Cold Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 200,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13877,13 +11284,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 60.793303,
-        "longitude": -161.755796,
         "name": "Bethel",
-        "namealt": null,
         "national": null,
         "pop_max": 6228,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13899,13 +11302,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 68.347726,
-        "longitude": -166.808020,
         "name": "Point Hope",
-        "namealt": null,
         "national": null,
         "pop_max": 461,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13921,13 +11320,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 71.290570,
-        "longitude": -156.788580,
         "name": "Barrow",
-        "namealt": null,
         "national": null,
         "pop_max": 4336,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13943,13 +11338,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.506100,
-        "longitude": -165.406374,
         "name": "Nome",
-        "namealt": null,
         "national": null,
         "pop_max": 3485,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13965,13 +11356,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.135996,
-        "longitude": -146.348287,
         "name": "Valdez",
-        "namealt": null,
         "national": null,
         "pop_max": 4036,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -13987,13 +11374,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 58.314127,
-        "longitude": -134.419997,
         "name": "Juneau",
-        "namealt": null,
         "national": null,
         "pop_max": 30711,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -14009,13 +11392,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 64.836984,
-        "longitude": -147.710659,
         "name": "Fairbanks",
-        "namealt": null,
         "national": null,
         "pop_max": 56993,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -14031,13 +11410,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 70.292181,
-        "longitude": -148.669360,
         "name": "Prudhoe Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 2500,
-        "scalerank": 3,
         "visible": 0
       },
       "type": "Feature"
@@ -14053,13 +11428,9 @@
       "properties": {
         "adm1name": "Alaska",
         "align": null,
-        "latitude": 61.219970,
-        "longitude": -149.900215,
         "name": "Anchorage",
-        "namealt": null,
         "national": null,
         "pop_max": 260283,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -14075,13 +11446,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 42.833004,
-        "longitude": -108.732599,
         "name": "Lander",
-        "namealt": null,
         "national": null,
         "pop_max": 6821,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14097,13 +11464,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 44.758675,
-        "longitude": -108.758437,
         "name": "Powell",
-        "namealt": null,
         "national": null,
         "pop_max": 6895,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14119,13 +11482,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 41.514558,
-        "longitude": -109.464983,
         "name": "Green River",
-        "namealt": null,
         "national": null,
         "pop_max": 11358,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14141,13 +11500,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 41.790665,
-        "longitude": -107.234292,
         "name": "Rawlins",
-        "namealt": null,
         "national": null,
         "pop_max": 8533,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14163,13 +11518,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 42.756472,
-        "longitude": -105.384534,
         "name": "Douglas",
-        "namealt": null,
         "national": null,
         "pop_max": 6298,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14185,13 +11536,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 43.028160,
-        "longitude": -108.395048,
         "name": "Riverton",
-        "namealt": null,
         "national": null,
         "pop_max": 11508,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14207,13 +11554,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 43.645978,
-        "longitude": -108.214671,
         "name": "Thermopolis",
-        "namealt": null,
         "national": null,
         "pop_max": 3445,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14229,13 +11572,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 44.283174,
-        "longitude": -105.505250,
         "name": "Gillette",
-        "namealt": null,
         "national": null,
         "pop_max": 29113,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -14251,13 +11590,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 41.311366,
-        "longitude": -105.590568,
         "name": "Laramie",
-        "namealt": null,
         "national": null,
         "pop_max": 26934,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -14273,13 +11608,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 44.523211,
-        "longitude": -109.057101,
         "name": "Cody",
-        "namealt": null,
         "national": null,
         "pop_max": 9161,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -14295,13 +11626,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 42.866620,
-        "longitude": -106.312488,
         "name": "Casper",
-        "namealt": null,
         "national": null,
         "pop_max": 60791,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -14317,13 +11644,9 @@
       "properties": {
         "adm1name": "Wyoming",
         "align": null,
-        "latitude": 41.140007,
-        "longitude": -104.819711,
         "name": "Cheyenne",
-        "namealt": null,
         "national": null,
         "pop_max": 72927,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -14339,13 +11662,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 44.551892,
-        "longitude": -69.645785,
         "name": "Waterville",
-        "namealt": null,
         "national": null,
         "pop_max": 25152,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14361,13 +11680,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 45.165989,
-        "longitude": -67.242392,
         "name": "Calais",
-        "namealt": null,
         "national": null,
         "pop_max": 3306,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14383,13 +11698,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 46.125517,
-        "longitude": -67.839720,
         "name": "Houlton",
-        "namealt": null,
         "national": null,
         "pop_max": 6703,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14405,13 +11716,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 44.387897,
-        "longitude": -68.204375,
         "name": "Bar Harbor",
-        "namealt": null,
         "national": null,
         "pop_max": 6090,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14426,14 +11733,10 @@
       },
       "properties": {
         "adm1name": "Maine",
-        "align": null,
-        "latitude": 44.100705,
-        "longitude": -70.215260,
+        "align": "left",
         "name": "Lewiston",
-        "namealt": null,
         "national": null,
         "pop_max": 57688,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14449,13 +11752,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 46.793409,
-        "longitude": -68.002165,
         "name": "Presque Isle",
-        "namealt": null,
         "national": null,
         "pop_max": 9466,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14471,13 +11770,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 44.801153,
-        "longitude": -68.778345,
         "name": "Bangor",
-        "namealt": null,
         "national": null,
         "pop_max": 50213,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -14493,13 +11788,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 43.672162,
-        "longitude": -70.245527,
         "name": "Portland",
-        "namealt": null,
         "national": null,
         "pop_max": 135866,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -14515,13 +11806,9 @@
       "properties": {
         "adm1name": "Maine",
         "align": null,
-        "latitude": 44.310563,
-        "longitude": -69.779989,
         "name": "Augusta",
-        "namealt": null,
         "national": null,
         "pop_max": 24042,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -14537,13 +11824,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.937999,
-        "longitude": -77.790766,
         "name": "Rocky Mount",
-        "namealt": null,
         "national": null,
         "pop_max": 58361,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14559,13 +11842,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.670780,
-        "longitude": -80.474478,
         "name": "Salisbury",
-        "namealt": null,
         "national": null,
         "pop_max": 41352,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14581,13 +11860,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.999959,
-        "longitude": -78.920000,
         "name": "Durham",
-        "namealt": null,
         "national": null,
         "pop_max": 309495,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14603,13 +11878,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 34.627200,
-        "longitude": -79.011906,
         "name": "Lumberton",
-        "namealt": null,
         "national": null,
         "pop_max": 32785,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14625,13 +11896,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 34.754324,
-        "longitude": -77.430556,
         "name": "Jacksonville",
-        "namealt": null,
         "national": null,
         "pop_max": 77288,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14647,13 +11914,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.385139,
-        "longitude": -77.993054,
         "name": "Goldsboro",
-        "namealt": null,
         "national": null,
         "pop_max": 47602,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14669,13 +11932,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.612877,
-        "longitude": -77.366684,
         "name": "Greenville",
-        "namealt": null,
         "national": null,
         "pop_max": 92565,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14691,13 +11950,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.062936,
-        "longitude": -78.883594,
         "name": "Fayetteville",
-        "namealt": null,
         "national": null,
         "pop_max": 243306,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14713,13 +11968,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.733489,
-        "longitude": -81.341402,
         "name": "Hickory",
-        "namealt": null,
         "national": null,
         "pop_max": 89462,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14735,13 +11986,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.601198,
-        "longitude": -82.554145,
         "name": "Asheville",
-        "namealt": null,
         "national": null,
         "pop_max": 142755,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14757,13 +12004,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 36.105431,
-        "longitude": -80.259995,
         "name": "Winston-Salem",
-        "namealt": null,
         "national": null,
         "pop_max": 281683,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14779,13 +12022,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 36.077319,
-        "longitude": -75.704718,
         "name": "Kitty Hawk",
-        "namealt": null,
         "national": null,
         "pop_max": 3413,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -14801,13 +12040,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 36.070006,
-        "longitude": -79.800023,
         "name": "Greensboro",
-        "namealt": null,
         "national": null,
         "pop_max": 388887,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -14823,13 +12058,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.204995,
-        "longitude": -80.830038,
         "name": "Charlotte",
-        "namealt": null,
         "national": null,
         "pop_max": 995000,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -14845,13 +12076,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 34.225519,
-        "longitude": -77.945020,
         "name": "Wilmington",
-        "namealt": null,
         "national": null,
         "pop_max": 161560,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -14867,13 +12094,9 @@
       "properties": {
         "adm1name": "North Carolina",
         "align": null,
-        "latitude": 35.818781,
-        "longitude": -78.644693,
         "name": "Raleigh",
-        "namealt": null,
         "national": null,
         "pop_max": 1163515,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -14889,13 +12112,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.750829,
-        "longitude": -87.714424,
         "name": "Sheboygan",
-        "namealt": null,
         "national": null,
         "pop_max": 53705,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14911,13 +12130,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.011650,
-        "longitude": -88.231369,
         "name": "Waukesha",
-        "namealt": null,
         "national": null,
         "pop_max": 249912,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14933,13 +12148,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.801369,
-        "longitude": -91.239429,
         "name": "La Crosse",
-        "namealt": null,
         "national": null,
         "pop_max": 87381,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14955,13 +12166,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 44.811359,
-        "longitude": -91.498353,
         "name": "Eau Claire",
-        "namealt": null,
         "national": null,
         "pop_max": 79740,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -14977,13 +12184,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.985053,
-        "longitude": -90.503892,
         "name": "Tomah",
-        "namealt": null,
         "national": null,
         "pop_max": 12997,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -14999,13 +12202,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 42.682626,
-        "longitude": -89.021579,
         "name": "Janesville",
-        "namealt": null,
         "national": null,
         "pop_max": 69278,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15021,13 +12220,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 44.268679,
-        "longitude": -88.400506,
         "name": "Appleton",
-        "namealt": null,
         "national": null,
         "pop_max": 203665,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15043,13 +12238,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 46.721242,
-        "longitude": -92.103898,
         "name": "Superior",
-        "namealt": null,
         "national": null,
         "pop_max": 27580,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15065,13 +12256,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.425707,
-        "longitude": -88.183336,
         "name": "West Bend",
-        "namealt": null,
         "national": null,
         "pop_max": 34530,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15087,13 +12274,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.773438,
-        "longitude": -88.446912,
         "name": "Fond du Lac",
-        "namealt": null,
         "national": null,
         "pop_max": 54299,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15109,13 +12292,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 44.025102,
-        "longitude": -88.542513,
         "name": "Oshkosh",
-        "namealt": null,
         "national": null,
         "pop_max": 72698,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15131,13 +12310,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 45.639913,
-        "longitude": -89.412072,
         "name": "Rhinelander",
-        "namealt": null,
         "national": null,
         "pop_max": 11483,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15153,13 +12328,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 42.727714,
-        "longitude": -87.811834,
         "name": "Racine",
-        "namealt": null,
         "national": null,
         "pop_max": 131654,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15175,13 +12346,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 45.100385,
-        "longitude": -87.630476,
         "name": "Marinette",
-        "namealt": null,
         "national": null,
         "pop_max": 27169,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15197,13 +12364,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.073016,
-        "longitude": -89.401117,
         "name": "Madison",
-        "namealt": null,
         "national": null,
         "pop_max": 327447,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -15219,13 +12382,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 44.529981,
-        "longitude": -88.000014,
         "name": "Green Bay",
-        "namealt": null,
         "national": null,
         "pop_max": 198611,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -15241,13 +12400,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 44.959154,
-        "longitude": -89.629992,
         "name": "Wausau",
-        "namealt": null,
         "national": null,
         "pop_max": 75422,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -15263,13 +12418,9 @@
       "properties": {
         "adm1name": "Wisconsin",
         "align": null,
-        "latitude": 43.052655,
-        "longitude": -87.919967,
         "name": "Milwaukee",
-        "namealt": null,
         "national": null,
         "pop_max": 1388000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -15285,13 +12436,9 @@
       "properties": {
         "adm1name": "New Hampshire",
         "align": "bottom",
-        "latitude": 42.995992,
-        "longitude": -71.455287,
         "name": "Manchester",
-        "namealt": null,
         "national": null,
         "pop_max": 196566,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -15307,13 +12454,9 @@
       "properties": {
         "adm1name": "New Hampshire",
         "align": null,
-        "latitude": 43.208072,
-        "longitude": -71.538047,
         "name": "Concord",
-        "namealt": null,
         "national": null,
         "pop_max": 44606,
-        "scalerank": 6,
         "visible": 1
       },
       "type": "Feature"
@@ -15329,13 +12472,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": "bottom",
-        "latitude": 34.968911,
-        "longitude": -90.003457,
         "name": "Southaven",
-        "namealt": null,
         "national": null,
         "pop_max": 121268,
-        "scalerank": 8,
         "visible": 1
       },
       "type": "Feature"
@@ -15351,13 +12490,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 32.364186,
-        "longitude": -88.703614,
         "name": "Meridian",
-        "namealt": null,
         "national": null,
         "pop_max": 42290,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15373,13 +12508,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 31.697379,
-        "longitude": -89.139273,
         "name": "Laurel",
-        "namealt": null,
         "national": null,
         "pop_max": 28841,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15395,13 +12526,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 30.367564,
-        "longitude": -89.092764,
         "name": "Gulfport",
-        "namealt": null,
         "national": null,
         "pop_max": 82165,
-        "scalerank": 7,
         "visible": 1
       },
       "type": "Feature"
@@ -15417,13 +12544,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 31.327273,
-        "longitude": -89.290245,
         "name": "Hattiesburg",
-        "namealt": null,
         "national": null,
         "pop_max": 58874,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15439,13 +12562,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 34.257921,
-        "longitude": -88.703330,
         "name": "Tupelo",
-        "namealt": null,
         "national": null,
         "pop_max": 35956,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15461,13 +12580,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 33.410375,
-        "longitude": -91.061687,
         "name": "Greenville",
-        "namealt": null,
         "national": null,
         "pop_max": 38107,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15483,13 +12598,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 31.554804,
-        "longitude": -91.387507,
         "name": "Natchez",
-        "namealt": null,
         "national": null,
         "pop_max": 23863,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15505,13 +12616,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 30.395805,
-        "longitude": -88.885309,
         "name": "Biloxi",
-        "namealt": null,
         "national": null,
         "pop_max": 50644,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -15527,13 +12634,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 32.352481,
-        "longitude": -90.877745,
         "name": "Vicksburg",
-        "namealt": null,
         "national": null,
         "pop_max": 25701,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -15549,13 +12652,9 @@
       "properties": {
         "adm1name": "Mississippi",
         "align": null,
-        "latitude": 32.298815,
-        "longitude": -90.184997,
         "name": "Jackson",
-        "namealt": null,
         "national": null,
         "pop_max": 250902,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -15571,13 +12670,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 38.066990,
-        "longitude": -117.228979,
         "name": "Tonopah",
-        "namealt": null,
         "national": null,
         "pop_max": 3261,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15593,13 +12688,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 35.978952,
-        "longitude": -114.831580,
         "name": "Boulder City",
-        "namealt": null,
         "national": null,
         "pop_max": 15479,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15615,13 +12706,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 40.973376,
-        "longitude": -117.734685,
         "name": "Winnemucca",
-        "namealt": null,
         "national": null,
         "pop_max": 9666,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15637,13 +12724,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 39.247022,
-        "longitude": -114.887675,
         "name": "Ely",
-        "namealt": null,
         "national": null,
         "pop_max": 4216,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -15659,14 +12742,10 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 39.163848,
-        "longitude": -119.766395,
         "name": "Carson City",
-        "namealt": null,
         "national": null,
         "pop_max": 57341,
-        "scalerank": 6,
-        "visible": 1
+        "visible": 0
       },
       "type": "Feature"
     },
@@ -15681,13 +12760,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 39.529976,
-        "longitude": -119.820010,
         "name": "Reno",
-        "namealt": null,
         "national": null,
         "pop_max": 328585,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -15703,13 +12778,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 40.832506,
-        "longitude": -115.761989,
         "name": "Elko",
-        "namealt": null,
         "national": null,
         "pop_max": 19252,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -15725,13 +12796,9 @@
       "properties": {
         "adm1name": "Nevada",
         "align": null,
-        "latitude": 36.209998,
-        "longitude": -115.220006,
         "name": "Las Vegas",
-        "namealt": null,
         "national": 1,
         "pop_max": 1823000,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -15747,13 +12814,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 48.112217,
-        "longitude": -98.859687,
         "name": "Devils Lake",
-        "namealt": null,
         "national": null,
         "pop_max": 7813,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15769,13 +12832,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 46.883997,
-        "longitude": -102.788801,
         "name": "Dickinson",
-        "namealt": null,
         "national": null,
         "pop_max": 16399,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15791,13 +12850,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 46.906012,
-        "longitude": -98.702978,
         "name": "Jamestown",
-        "namealt": null,
         "national": null,
         "pop_max": 15081,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15813,13 +12868,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 48.156788,
-        "longitude": -103.628001,
         "name": "Williston",
-        "namealt": null,
         "national": null,
         "pop_max": 13564,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -15835,13 +12886,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 47.925278,
-        "longitude": -97.032486,
         "name": "Grand Forks",
-        "namealt": null,
         "national": null,
         "pop_max": 58566,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -15857,13 +12904,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 48.232494,
-        "longitude": -101.295817,
         "name": "Minot",
-        "namealt": null,
         "national": null,
         "pop_max": 39439,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -15878,14 +12921,10 @@
       },
       "properties": {
         "adm1name": "North Dakota",
-        "align": null,
-        "latitude": 46.877228,
-        "longitude": -96.789426,
+        "align": "right",
         "name": "Fargo",
-        "namealt": null,
         "national": null,
         "pop_max": 162842,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -15901,13 +12940,9 @@
       "properties": {
         "adm1name": "North Dakota",
         "align": null,
-        "latitude": 46.808317,
-        "longitude": -100.783316,
         "name": "Bismarck",
-        "namealt": null,
         "national": null,
         "pop_max": 63871,
-        "scalerank": 3,
         "visible": 1
       },
       "type": "Feature"
@@ -15923,13 +12958,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.021919,
-        "longitude": -81.733006,
         "name": "Winter Haven",
-        "namealt": null,
         "national": null,
         "pop_max": 108932,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15945,13 +12976,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.083310,
-        "longitude": -80.608320,
         "name": "Melbourne",
-        "namealt": null,
         "national": null,
         "pop_max": 265414,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15967,13 +12994,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 25.468302,
-        "longitude": -80.477786,
         "name": "Homestead",
-        "namealt": null,
         "national": null,
         "pop_max": 85967,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -15989,13 +13012,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.789960,
-        "longitude": -81.279985,
         "name": "Sanford",
-        "namealt": null,
         "national": null,
         "pop_max": 333460,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16011,13 +13030,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 25.809920,
-        "longitude": -80.131781,
         "name": "Miami Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 407750,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16033,13 +13048,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.270837,
-        "longitude": -80.270822,
         "name": "Coral Springs",
-        "namealt": null,
         "national": null,
         "pop_max": 250000,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16055,13 +13066,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.000043,
-        "longitude": -82.105697,
         "name": "Port Charlotte",
-        "namealt": null,
         "national": null,
         "pop_max": 64279,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16077,13 +13084,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.478945,
-        "longitude": -82.547711,
         "name": "Spring Hill",
-        "namealt": null,
         "national": null,
         "pop_max": 114697,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16099,13 +13102,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.538002,
-        "longitude": -81.223296,
         "name": "Palm Coast",
-        "namealt": null,
         "national": null,
         "pop_max": 48577,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16121,13 +13120,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.647685,
-        "longitude": -81.651306,
         "name": "Palatka",
-        "namealt": null,
         "national": null,
         "pop_max": 21452,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16143,13 +13138,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.810501,
-        "longitude": -81.883333,
         "name": "Leesburg",
-        "namealt": null,
         "national": null,
         "pop_max": 49574,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16165,13 +13156,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.189719,
-        "longitude": -82.639747,
         "name": "Lake City",
-        "namealt": null,
         "national": null,
         "pop_max": 29395,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16187,13 +13174,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.754207,
-        "longitude": -86.572607,
         "name": "Crestview",
-        "namealt": null,
         "national": null,
         "pop_max": 22403,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16209,13 +13192,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.158610,
-        "longitude": -85.655273,
         "name": "Panama City",
-        "namealt": null,
         "national": null,
         "pop_max": 100072,
-        "scalerank": 8,
         "visible": 0
       },
       "type": "Feature"
@@ -16231,13 +13210,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 25.715419,
-        "longitude": -80.291079,
         "name": "Coral Gables",
-        "namealt": null,
         "national": null,
         "pop_max": 150000,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16253,13 +13228,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.602910,
-        "longitude": -81.979684,
         "name": "Cape Coral",
-        "namealt": null,
         "national": null,
         "pop_max": 132489,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16275,13 +13246,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.142059,
-        "longitude": -81.794992,
         "name": "Naples",
-        "namealt": null,
         "national": null,
         "pop_max": 262306,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16297,13 +13264,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.446786,
-        "longitude": -80.325805,
         "name": "Fort Pierce",
-        "namealt": null,
         "national": null,
         "pop_max": 228245,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16319,13 +13282,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.292057,
-        "longitude": -81.407781,
         "name": "Kissimmee",
-        "namealt": null,
         "national": null,
         "pop_max": 225494,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16341,13 +13300,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.612348,
-        "longitude": -80.807791,
         "name": "Titusville",
-        "namealt": null,
         "national": null,
         "pop_max": 52311,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16363,13 +13318,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.894879,
-        "longitude": -81.314711,
         "name": "St. Augustine",
-        "namealt": null,
         "national": null,
         "pop_max": 76331,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16385,13 +13336,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.187352,
-        "longitude": -82.140268,
         "name": "Ocala",
-        "namealt": null,
         "national": null,
         "pop_max": 141382,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16407,13 +13354,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.136065,
-        "longitude": -80.141786,
         "name": "Fort Lauderdale",
-        "namealt": null,
         "national": null,
         "pop_max": 2042042,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16429,13 +13372,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.725613,
-        "longitude": -84.992523,
         "name": "Apalachicola",
-        "namealt": null,
         "national": null,
         "pop_max": 2284,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16451,13 +13390,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.642252,
-        "longitude": -80.391124,
         "name": "Vero Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 86039,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16473,13 +13408,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.421126,
-        "longitude": -87.216935,
         "name": "Pensacola",
-        "namealt": null,
         "national": null,
         "pop_max": 234384,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16495,13 +13426,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.770539,
-        "longitude": -82.679383,
         "name": "St. Petersburg",
-        "namealt": null,
         "national": null,
         "pop_max": 800313,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16517,13 +13444,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 24.555231,
-        "longitude": -81.782745,
         "name": "Key West",
-        "namealt": null,
         "national": null,
         "pop_max": 29377,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16539,13 +13462,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.745020,
-        "longitude": -80.123621,
         "name": "West Palm Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 1250000,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16561,13 +13480,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.336121,
-        "longitude": -82.530787,
         "name": "Sarasota",
-        "namealt": null,
         "national": null,
         "pop_max": 589959,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16583,13 +13498,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.210554,
-        "longitude": -81.023075,
         "name": "Daytona Beach",
-        "namealt": null,
         "national": null,
         "pop_max": 216890,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16605,13 +13516,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 29.651380,
-        "longitude": -82.325037,
         "name": "Gainesville",
-        "namealt": null,
         "national": null,
         "pop_max": 191097,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16627,13 +13534,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 26.640298,
-        "longitude": -81.860492,
         "name": "Ft. Myers",
-        "namealt": "Fort Myers",
         "national": null,
         "pop_max": 188606,
-        "scalerank": 6,
         "visible": 0
       },
       "type": "Feature"
@@ -16649,13 +13552,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.449988,
-        "longitude": -84.280034,
         "name": "Tallahassee",
-        "namealt": null,
         "national": null,
         "pop_max": 221222,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -16671,13 +13570,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 28.509977,
-        "longitude": -81.380030,
         "name": "Orlando",
-        "namealt": null,
         "national": null,
         "pop_max": 1350000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -16693,13 +13588,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 30.330021,
-        "longitude": -81.669987,
         "name": "Jacksonville",
-        "namealt": "Jacksonville, Florida",
         "national": null,
         "pop_max": 988000,
-        "scalerank": 4,
         "visible": 1
       },
       "type": "Feature"
@@ -16715,13 +13606,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": null,
-        "latitude": 27.946988,
-        "longitude": -82.458621,
         "name": "Tampa",
-        "namealt": "Tampa-St. Petersburg",
         "national": null,
         "pop_max": 2314000,
-        "scalerank": 2,
         "visible": 1
       },
       "type": "Feature"
@@ -16737,13 +13624,9 @@
       "properties": {
         "adm1name": "Florida",
         "align": "right",
-        "latitude": 25.787611,
-        "longitude": -80.224106,
         "name": "Miami",
-        "namealt": null,
         "national": 1,
         "pop_max": 5585000,
-        "scalerank": 1,
         "visible": 1
       },
       "type": "Feature"
@@ -16759,13 +13642,9 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 21.981512,
-        "longitude": -159.371006,
         "name": "Lihue",
-        "namealt": null,
         "national": null,
         "pop_max": 15536,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16781,13 +13660,9 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 21.503092,
-        "longitude": -158.023621,
         "name": "Wahiawa",
-        "namealt": null,
         "national": null,
         "pop_max": 174766,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16803,13 +13678,9 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 20.891475,
-        "longitude": -156.504721,
         "name": "Wailuku",
-        "namealt": null,
         "national": null,
         "pop_max": 52148,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16825,13 +13696,9 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 19.640556,
-        "longitude": -155.995556,
         "name": "Kailua-Kona",
-        "namealt": null,
         "national": null,
         "pop_max": 9870,
-        "scalerank": 7,
         "visible": 0
       },
       "type": "Feature"
@@ -16847,13 +13714,9 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 19.699998,
-        "longitude": -155.090027,
         "name": "Hilo",
-        "namealt": null,
         "national": null,
         "pop_max": 52391,
-        "scalerank": 4,
         "visible": 0
       },
       "type": "Feature"
@@ -16869,13 +13732,45 @@
       "properties": {
         "adm1name": "Hawaii",
         "align": null,
-        "latitude": 21.306876,
-        "longitude": -157.857998,
         "name": "Honolulu",
-        "namealt": null,
         "national": null,
         "pop_max": 786000,
-        "scalerank": 2,
+        "visible": 1
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -72.575813234126827,
+          44.259971536326248
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "adm1name": "Vermont",
+        "align": null,
+        "name": "Montpelier",
+        "national": null,
+        "pop_max": null,
+        "visible": 1
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [
+          -73.212466879962676,
+          44.47579815579337
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "adm1name": "Vermont",
+        "align": null,
+        "name": "Burlington",
+        "national": null,
+        "pop_max": null,
         "visible": 1
       },
       "type": "Feature"

--- a/upload
+++ b/upload
@@ -8,10 +8,13 @@ KEY="map-data/$TILESET.mbtiles"
 
 if [[ -z $FORCE_UPLOAD ]]; then
   if aws s3api head-object --bucket $BUCKET --key $KEY; then
-    echo $KEY already exists in S3 bucket $BUCKET. Aborting.
-    exit 1
+    echo $KEY already exists in S3 bucket $BUCKET. Skipping.
+    exit
   fi
 fi
 
-node_modules/.bin/mapbox-upload $TILESET $FILENAME
+if [[ -z $SKIP_MAPBOX ]]; then
+  node_modules/.bin/mapbox-upload $TILESET $FILENAME
+fi
+
 aws s3 cp $FILENAME "s3://$BUCKET/$KEY"


### PR DESCRIPTION
This

- Removes the functions that had been making elections.mbtiles
- Adds `tile-factory-%:`, which takes any of `states, counties, districts_114, districts_115, or precincts` makes tiles for them for each zoom level, and then merges those individual layers into one.
- Finally, `tiles/election-state-labels.mbtiles` generates the tiles for state labels.

This makes #12 obsolete.

@anandthakker  @dereklieu 